### PR TITLE
Set the company name field to be current employer for individuals

### DIFF
--- a/CRM/Civiquickbooks/Contact.php
+++ b/CRM/Civiquickbooks/Contact.php
@@ -341,6 +341,14 @@ class CRM_Civiquickbooks_Contact {
       ),
     );
 
+    // This sets the company name field for Individuals to be their current
+    // employer (if the contact has a current employer). Presumbably contacts of
+    // the type "Individual" will never have an "organization_name" as that
+    // field is for contacts of the type "Organization"
+    if ($contact['contact_type'] == 'Individual' && !empty($contact['current_employer']) && empty($contact['organization_name'])) {
+      $customer["CompanyName"] = $contact['current_employer'];
+    }
+
     if (isset($accountsID)) {
       if (isset($customer_data)) {
         //NOTE here the customer_data is deserialized as an array.


### PR DESCRIPTION
When generating invoices for contacts of the type "Individual", this change makes it so the "Company Name" field is populated as the "Current Employer" of the Individual (if they have one). 

Before this change the "Company Name" field was always set as the "Organization Name"  which only exists on contacts of the type "Organization" and thus would always be blank  (unless there was funny business).