### PR TITLE
Bug fixes in Settings form

### DIFF
--- a/CRM/Civiquickbooks/Form/Settings.php
+++ b/CRM/Civiquickbooks/Form/Settings.php
@@ -141,6 +141,16 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
     $values = array_intersect_key($this->_submittedValues, $settings);
     $previousValues = CRM_Quickbooks_APIHelper::getQuickBooksCredentials();
 
+    // Fix for unsetting a checkbox. When setting a checkbox,
+    // quickbooks_bool_value => 1 is returned. But when unsetting a checkbox,
+    // quickbooks_bool_value => 0 is NOT returned. Absence of a checkbox
+    // attribute should be interpreted as setting its value to 0.
+    foreach ($settings as $setting_name => $setting_info) {
+        if ($setting_info['type'] == "Boolean" && !array_key_exists($setting_name, $values)) {
+            $values[$setting_name] = 0;
+        }
+    }
+
     civicrm_api3('setting', 'create', $values);
 
     if ($previousValues['clientID'] != 'quickbooks_consumer_key' || $previousValues['clientSecret'] != 'quickbooks_shared_secret') {


### PR DESCRIPTION
… existing credentials when client info changes.

Checkbox bug fix needed for new features involving boolean settings.

Credential invalidation code bug fix - although FYI this doesn't fix the issue I'm having where changing any setting causes credentials to be invalidated.