### PR TITLE
Fixes

### DIFF
--- a/CRM/Civiquickbooks/Contact.php
+++ b/CRM/Civiquickbooks/Contact.php
@@ -1,6 +1,8 @@
 <?php
 
 /** Load CiviX ExtensionUtil class and bundled autoload resolver. **/
+
+use Civi\Api4\EntityTag;
 use CRM_Civiquickbooks_ExtensionUtil as E;
 
 require E::path('vendor/autoload.php');
@@ -290,6 +292,9 @@ class CRM_Civiquickbooks_Contact {
 
             civicrm_api3('account_contact', 'create', $account_contact);
           }
+
+          // Success! Remove sync error tag
+          CRM_Civiquickbooks_Helper::removeSyncErrorTag($account_contact['contact_id']);
         } catch (Exception $e) {
           $errors[] = ts(
             'Failed to push Contact: %1 (AccountsContact: %2) with error: %3',
@@ -298,6 +303,8 @@ class CRM_Civiquickbooks_Contact {
               2 => $account_contact['accounts_contact_id'],
               3 => $e->getMessage()
             ]);
+          // Add sync error tag
+          CRM_Civiquickbooks_Helper::addSyncErrorTag($account_contact['contact_id']);
         }
       }
 

--- a/CRM/Civiquickbooks/Helper.php
+++ b/CRM/Civiquickbooks/Helper.php
@@ -1,0 +1,41 @@
+<?php
+
+use Civi\Api4\EntityTag;
+
+class CRM_Civiquickbooks_Helper {
+
+  /**
+   * @param int $contactID
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public static function addSyncErrorTag(int $contactID) {
+    if (empty(EntityTag::get(FALSE)
+      ->addWhere('entity_table:name', '=', 'Contact')
+      ->addWhere('entity_id', '=', $contactID)
+      ->addWhere('tag_id:name', '=', 'Quickbooks Sync Error')
+      ->execute()->count())) {
+      EntityTag::create(FALSE)
+        ->addValue('entity_table:name', 'Contact')
+        ->addValue('entity_id', $contactID)
+        ->addValue('tag_id:name', 'Quickbooks Sync Error')
+        ->execute();
+    }
+  }
+
+  /**
+   * @param int $contactID
+   *
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public static function removeSyncErrorTag(int $contactID) {
+    EntityTag::delete(FALSE)
+      ->addWhere('entity_table:name', '=', 'Contact')
+      ->addWhere('entity_id', '=', $contactID)
+      ->addWhere('tag_id:name', '=', 'Quickbooks Sync Error')
+      ->execute();
+  }
+
+}

--- a/CRM/Civiquickbooks/Invoice.php
+++ b/CRM/Civiquickbooks/Invoice.php
@@ -113,11 +113,7 @@ class CRM_Civiquickbooks_Invoice {
           }
 
         } catch (Exception $e) {
-          $messages = json_decode($e->getMessage());
-
-          if (is_null($messages)) {
-            $messages = $e->getMessage();
-          }
+          $messages = $e->getMessage();
 
           $errors[] = $this_error = ts('Failed to store %1 with error %2.', [
             1 => $record['contribution_id'],

--- a/CRM/Civiquickbooks/Invoice.php
+++ b/CRM/Civiquickbooks/Invoice.php
@@ -28,7 +28,7 @@ class CRM_Civiquickbooks_Invoice {
 
     $this->contribution_status = $this->contribution_status['values'];
 
-    $this->contribution_status_by_value = array();
+    $this->contribution_status_by_value = [];
 
     foreach ($this->contribution_status as $key => $value) {
       $this->contribution_status[$key] = strtolower($value);
@@ -53,38 +53,39 @@ class CRM_Civiquickbooks_Invoice {
    * @return bool
    *
    * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
    * @throws \QuickBooksOnline\API\Exception\IdsException
    * @throws \QuickBooksOnline\API\Exception\SdkException
    */
-  public function push($params = array(), $limit = PHP_INT_MAX) {
+  public function push($params = [], $limit = PHP_INT_MAX) {
     try {
       $records = $this->findPushContributions($params, $limit);
-      $errors = array();
+      $errors = [];
 
       // US companies handles the tax in Invoice differently
-      $company_country = civicrm_api3('Setting', 'getvalue', array(
+      $company_country = civicrm_api3('Setting', 'getvalue', [
         'name' => "quickbooks_company_country",
         'group' => 'QuickBooks Online Settings',
-      ));
+      ]);
       $this->us_company = ($company_country == 'US');
 
       foreach ($records['values'] as $i => $record) {
         try {
           $accountsInvoice = $this->getAccountsInvoice($record);
 
-          if(empty($accountsInvoice)) {
-              civicrm_api3('AccountInvoice', 'create', ['id' => $record['id'], 'accounts_needs_update' => 0]);
-              throw new CiviCRM_API3_Exception(E::ts('AccountInvoice object for %1 is empty', [1 => $record['id']]), 'empty_invoice');
+          if (empty($accountsInvoice)) {
+            civicrm_api3('AccountInvoice', 'create', ['id' => $record['id'], 'accounts_needs_update' => 0]);
+            throw new CiviCRM_API3_Exception(E::ts('AccountInvoice object for %1 is empty', [1 => $record['id']]), 'empty_invoice');
           }
 
           $proceed = TRUE;
           CRM_Accountsync_Hook::accountPushAlterMapped('invoice', $record, $proceed, $accountsInvoice);
 
-          if(!$proceed) {
+          if (!$proceed) {
             continue;
           }
 
-          $responseError='';
+          $responseError = '';
 
           $dataService = CRM_Quickbooks_APIHelper::getAccountingDataServiceObject();
 
@@ -118,15 +119,15 @@ class CRM_Civiquickbooks_Invoice {
             $messages = $e->getMessage();
           }
 
-          $errors[] =$this_error = ts('Failed to store %1 with error %2.', [
-                       1 => $record['contribution_id'],
-                       2 => $messages,
-                     ]);
+          $errors[] = $this_error = ts('Failed to store %1 with error %2.', [
+            1 => $record['contribution_id'],
+            2 => $messages,
+          ]);
 
           civicrm_api3('AccountInvoice', 'create', [
-              'id' => $record['id'],
-              'error_data' => json_encode([ date('c'), [ 'message' => $messages ] ]),
-            ]);
+            'id' => $record['id'],
+            'error_data' => json_encode([date('c'), ['message' => $messages]]),
+          ]);
 
           CRM_Core_Error::debug_log_message($this_error);
         }
@@ -137,16 +138,24 @@ class CRM_Civiquickbooks_Invoice {
         throw new CRM_Core_Exception(ts('Not all records were saved: ') . json_encode($errors, JSON_PRETTY_PRINT), 'incomplete', $errors);
       }
       return TRUE;
-    } catch (CiviCRM_API3_Exception $e) {
+    }
+    catch (CiviCRM_API3_Exception $e) {
       throw new CRM_Core_Exception('Invoice Push aborted due to: ' . $e->getMessage());
     }
   }
 
-  public function pull($params = array(), $limit = PHP_INT_MAX) {
+  /**
+   * @param array $params
+   * @param int $limit
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function pull($params = [], $limit = PHP_INT_MAX) {
     try {
       $records = $this->findPullContributions($params, $limit);
 
-      $errors = array();
+      $errors = [];
 
       foreach ($records['values'] as $i => $record) {
         try {
@@ -193,7 +202,11 @@ class CRM_Civiquickbooks_Invoice {
    * @throws \QuickBooksOnline\API\Exception\IdsException
    */
   public static function pushPayments($contribution_id, $account_invoice) {
-    $payments = civicrm_api3('Payment', 'get', ['contribution_id' => $contribution_id, 'status_id' => 'Completed', 'sequential' => 1]);
+    $payments = civicrm_api3('Payment', 'get', [
+      'contribution_id' => $contribution_id,
+      'status_id' => 'Completed',
+      'sequential' => 1,
+    ]);
 
     if (!$payments['count']) {
       return;
@@ -202,7 +215,7 @@ class CRM_Civiquickbooks_Invoice {
     $dataService = CRM_Quickbooks_APIHelper::getAccountingDataServiceObject();
     $result = [];
 
-    foreach($payments['values'] as $payment) {
+    foreach ($payments['values'] as $payment) {
       $txnDate = $payment['trxn_date'];
       $total = sprintf('%.5f', $payment['total_amount']);
       $QBOPayment = \QuickBooksOnline\API\Facades\Payment::create(
@@ -213,10 +226,12 @@ class CRM_Civiquickbooks_Invoice {
           'TxnDate' => $txnDate,
           'Line' => [
             'Amount' => $total,
-            'LinkedTxn' => [[
-              'TxnType' => 'Invoice',
-              'TxnId' => $account_invoice->Id,
-            ]],
+            'LinkedTxn' => [
+              [
+                'TxnType' => 'Invoice',
+                'TxnId' => $account_invoice->Id,
+              ],
+            ],
           ],
         ]
       );
@@ -237,13 +252,13 @@ class CRM_Civiquickbooks_Invoice {
    * @throws \QuickBooksOnline\API\Exception\IdsException
    */
   public static function sendEmail($invoice_id, $dataService = NULL) {
-    if($dataService == NULL) {
+    if ($dataService == NULL) {
       $dataService = CRM_Quickbooks_APIHelper::getAccountingDataServiceObject();
     }
 
-    $send = civicrm_api3('Setting', 'getvalue', [ 'name' => 'quickbooks_email_invoice' ]);
+    $send = civicrm_api3('Setting', 'getvalue', ['name' => 'quickbooks_email_invoice']);
 
-    switch($send) {
+    switch ($send) {
       case 'unpaid':
       case 'always':
         $invoice = $dataService->FindById('invoice', $invoice_id);
@@ -267,16 +282,24 @@ class CRM_Civiquickbooks_Invoice {
       return FALSE;
     }
 
-    $db_contribution = civicrm_api3('Contribution', 'getsingle', array(
-      'return' => array('contribution_status_id'),
+    $db_contribution = civicrm_api3('Contribution', 'getsingle', [
+      'return' => ['contribution_status_id'],
       'id' => $contributionID,
-    ));
+    ]);
 
     $db_contribution['contri_status_in_lower'] = strtolower($this->contribution_status[$db_contribution['contribution_status_id']]);
 
     return $db_contribution;
   }
 
+  /**
+   * @param $record
+   *
+   * @return \Exception|\QuickBooksOnline\API\Data\IPPIntuitEntity|string|null
+   * @throws \CiviCRM_API3_Exception
+   * @throws \QuickBooksOnline\API\Exception\IdsException
+   * @throws \QuickBooksOnline\API\Exception\SdkException
+   */
   protected function getInvoiceFromQBO($record) {
     $dataService = CRM_Quickbooks_APIHelper::getAccountingDataServiceObject();
     $dataService->throwExceptionOnError(FALSE);
@@ -284,9 +307,9 @@ class CRM_Civiquickbooks_Invoice {
     $invoice = $dataService->FindById('invoice', $record['accounts_invoice_id']);
 
     if ($last_error = $dataService->getLastError()) {
-        $error_message = CRM_Quickbooks_APIHelper::parseErrorResponse($last_error);
+      $error_message = CRM_Quickbooks_APIHelper::parseErrorResponse($last_error);
 
-        throw new Exception('"' . implode("\n", $error_message) . '"');
+      throw new Exception('"' . implode("\n", $error_message) . '"');
     }
 
     return $invoice;
@@ -303,10 +326,10 @@ class CRM_Civiquickbooks_Invoice {
 
     if ($invoice_status == 'paid') {
       if ($contribution['contri_status_in_lower'] != 'completed') {
-        $result = civicrm_api3('Contribution', 'completetransaction', array(
+        $result = civicrm_api3('Contribution', 'completetransaction', [
           'id' => $record['contribution_id'],
           'is_email_receipt' => 0,
-        ));
+        ]);
 
         if ($result['is_error']) {
           throw new CiviCRM_API3_Exception('Contribution status update failed: id: ' . $record['contribution_id'] . ' of Invoice ' . $invoice['Id'], 'qbo_contribution_status');
@@ -395,24 +418,24 @@ class CRM_Civiquickbooks_Invoice {
 
     $contributionID = $record['contribution_id'];
 
-    $db_contribution = civicrm_api3('Contribution', 'getsingle', array(
-      'return' => array(
+    $db_contribution = civicrm_api3('Contribution', 'getsingle', [
+      'return' => [
         'contribution_status_id',
         'receive_date',
         'contribution_source',
-      ),
+      ],
       'id' => $contributionID,
-    ));
+    ]);
 
     $db_contribution['status'] = $this->contribution_status[$db_contribution['contribution_status_id']];
 
-    $cancelledStatuses = array('failed', 'cancelled');
+    $cancelledStatuses = ['failed', 'cancelled'];
 
-    $qb_account = civicrm_api3('account_contact', 'getsingle', array(
+    $qb_account = civicrm_api3('account_contact', 'getsingle', [
       'contact_id' => $db_contribution['contact_id'],
       'plugin' => $this->plugin,
       'connector_id' => 0,
-    ));
+    ]);
 
     $qb_id = $qb_account['accounts_contact_id'];
 
@@ -450,40 +473,40 @@ class CRM_Civiquickbooks_Invoice {
    */
   protected function mapToAccounts($db_contribution, $accountsID, $SyncToken, $qb_id) {
     static $tmp = NULL;
-    $new_invoice = array();
+    $new_invoice = [];
     $contri_status_in_lower = strtolower($db_contribution['status']);
 
     //those contributions we care
-    $status_array = array('pending', 'completed', 'partially paid');
+    $status_array = ['pending', 'completed', 'partially paid'];
 
     $contributionID = $db_contribution['id'];
 
     if (in_array($contri_status_in_lower, $status_array)) {
-      $db_line_items = civicrm_api3('LineItem', 'get', array(
+      $db_line_items = civicrm_api3('LineItem', 'get', [
         'contribution_id' => $contributionID,
-      ));
+      ]);
 
       if (empty($db_line_items['count'])) {
         throw new CiviCRM_API3_Exception('No line item in contribution id ' . $contributionID . '; push aborted.', 'qbo_contribution_line_item');
       }
 
-      $line_items = array();
+      $line_items = [];
 
       /* static array for storing financial type and its Inc account's accounting code.
        * key: financial type id.
        * value: the accounting code of the Inc financial account of this financial type.*/
-      static $item_ref_codes = array();
+      static $item_ref_codes = [];
 
       /* static array for storing financial type and its Inc account's accounting code.
        * key: financial type id.
        * value: the accounting code of the sales tax account of this financial type.*/
-      static $tax_types = array();
+      static $tax_types = [];
 
       $result = NULL;
 
-      $item_codes = array();
+      $item_codes = [];
 
-      $tax_codes = array();
+      $tax_codes = [];
 
       //Collect all accounting codes for all line items
       foreach ($db_line_items['values'] as $id => $line_item) {
@@ -500,26 +523,26 @@ class CRM_Civiquickbooks_Invoice {
         //get Sales Tax Account accounting code if it is not collected previously
         if (!isset($tax_types[$line_item['financial_type_id']])) {
           try {
-            $result = civicrm_api3('EntityFinancialAccount', 'getsingle', array(
+            $result = civicrm_api3('EntityFinancialAccount', 'getsingle', [
               'sequential' => 1,
-              'return' => array("financial_account_id"),
+              'return' => ["financial_account_id"],
               'entity_id' => $line_item['financial_type_id'],
               'entity_table' => "civicrm_financial_type",
               'account_relationship' => "Sales Tax Account is",
-            ));
+            ]);
 
-            $result = civicrm_api3('FinancialAccount', 'getsingle', array(
+            $result = civicrm_api3('FinancialAccount', 'getsingle', [
               'sequential' => 1,
               'id' => $result['financial_account_id'],
-            ));
+            ]);
 
             $tmp = htmlspecialchars_decode($result['accounting_code']);
 
             // We will use account type code to get state tax code id for US companies
-            $tax_types[$line_item['financial_type_id']] = array(
+            $tax_types[$line_item['financial_type_id']] = [
               'sale_tax_acctgCode' => $tmp,
               'sale_tax_account_type_code' => htmlspecialchars_decode($result['account_type_code']),
-            );
+            ];
 
             $tax_codes[] = $tmp;
           } catch (CiviCRM_API3_Exception $e) {
@@ -543,18 +566,18 @@ class CRM_Civiquickbooks_Invoice {
 
       //looping through all line items and create an array that contains all necessary info for each line item.
       foreach ($db_line_items['values'] as $id => $line_item) {
-        $line_item_description = str_replace(array('&nbsp;'), ' ', $line_item['label']);
+        $line_item_description = str_replace(['&nbsp;'], ' ', $line_item['label']);
 
         try {
           $line_item_ref = self::getItem($line_item['acctgCode']);
         } catch (Exception $e) {
           $item_errormsg[] = ts(
             'No matching Item for accounting code "%1" (financial type %2) - %3',
-            array(
+            [
               1 => $line_item['acctgCode'],
               2 => $line_item['financial_type_id'],
-              3 => $e->getMessage()
-            )
+              3 => $e->getMessage(),
+            ]
           );
 
           continue;
@@ -562,12 +585,12 @@ class CRM_Civiquickbooks_Invoice {
 
         // For US companies, this process is not needed, as the `TaxCodeRef` for each line item is either `NON` or `TAX`.
         if (!$this->us_company) {
-          if(!empty($line_item['sale_tax_acctgCode'])){
+          if (!empty($line_item['sale_tax_acctgCode'])) {
             try {
               $line_item_tax_ref = self::getTaxCode($line_item['sale_tax_acctgCode']);
             } catch (\QuickbooksOnline\API\Exception\IdsException $e) {
               // Don't include any line items wih a non-matching TaxCode in Quickbooks.
-              $tax_errormsg[] = ts('No matching Tax type found in Quickbooks online for %1', array(1 => $line_item['sale_tax_acctgCode']));
+              $tax_errormsg[] = ts('No matching Tax type found in Quickbooks online for %1', [1 => $line_item['sale_tax_acctgCode']]);
             }
           }
         }
@@ -578,23 +601,23 @@ class CRM_Civiquickbooks_Invoice {
 
         $lineTotal = $line_item['line_total'];
 
-        $tmp = array(
+        $tmp = [
           'Id' => $i . '',
           'LineNum' => $i,
           'Description' => $line_item_description,
           'Amount' => sprintf('%.5f', $lineTotal),
           'DetailType' => 'SalesItemLineDetail',
-          'SalesItemLineDetail' => array(
-            'ItemRef' => array(
+          'SalesItemLineDetail' => [
+            'ItemRef' => [
               'value' => $line_item_ref,
-            ),
+            ],
             'UnitPrice' => $lineTotal / $line_item['qty'] * 1.00,
             'Qty' => $line_item['qty'] * 1,
-            'TaxCodeRef' => array(
+            'TaxCodeRef' => [
               'value' => $line_item_tax_ref,
-            ),
-          ),
-        );
+            ],
+          ],
+        ];
 
         $line_items[] = $tmp;
         $i += 1;
@@ -604,11 +627,11 @@ class CRM_Civiquickbooks_Invoice {
 
       $receive_date = $db_contribution['receive_date'];
 
-      $invoice_settings = civicrm_api3('Setting', 'getvalue', array(
+      $invoice_settings = civicrm_api3('Setting', 'getvalue', [
         'sequential' => 1,
         'name' => 'contribution_invoice_settings',
         'group_name' => 'Contribute Preferences',
-      ));
+      ]);
 
       if (!empty($invoice_settings['due_date']) && !empty($invoice_settings['due_date_period'])) {
         $time_adjust_str = '+' . $invoice_settings['due_date'] . ' ' . $invoice_settings['due_date_period'];
@@ -622,38 +645,37 @@ class CRM_Civiquickbooks_Invoice {
       // if we use `sparse = true` here. it means that the we are going to partially update the invoice, this approach sometimes causes update issue.
       // so do not use it.
       if (isset($SyncToken) && isset($accountsID)) {
-        $new_invoice += array(
+        $new_invoice += [
           'Id' => $accountsID,
           'SyncToken' => $SyncToken,
-        );
+        ];
       }
 
       if (empty($line_items)) {
         throw new CiviCRM_API3_Exception("No valid line items in the Invoice to push:\n" . $QBO_errormsg, 'qbo_invoice_line_items');
       }
 
-      $new_invoice += array(
+      $new_invoice += [
         'TxnDate' => $receive_date,
         'DueDate' => $due_date,
-        'CustomerMemo' => array(
+        'CustomerMemo' => [
           'value' => $db_contribution['contribution_source'],
-        ),
+        ],
         'Line' => $line_items,
-        'CustomerRef' => array(
+        'CustomerRef' => [
           'value' => $qb_id,
-        ),
+        ],
         'GlobalTaxCalculation' => 'TaxExcluded',
-      );
+      ];
 
       // check the setting 'Where should Invoice Numbers be generated?' and
       // populate the new invoice accordingly
       try {
-        $whereToGetInvoiceNumber = civicrm_api3('Setting', 'getvalue', array(
+        $whereToGetInvoiceNumber = civicrm_api3('Setting', 'getvalue', [
           'name' => 'quickbooks_autogenerate_invoice_number',
           'group' => 'QuickBooks Online Settings',
-        ));
-      }
-      catch (Exception $e) {
+        ]);
+      } catch (Exception $e) {
         throw new CiviCRM_API3_Exception(
           E::ts('Error getting Invoice generation setting %1', [1 => $e->getMessage()]),
           'qbo_invoice_creation'
@@ -674,12 +696,11 @@ class CRM_Civiquickbooks_Invoice {
       ];
       foreach ($onlinePaymentOptions as $settingNameInCivi => $qbParam) {
         try {
-          $allowCC = civicrm_api3('Setting', 'getvalue', array(
+          $allowCC = civicrm_api3('Setting', 'getvalue', [
             'name' => $settingNameInCivi,
             'group' => 'QuickBooks Online Settings',
-          ));
-        }
-        catch (Exception $e) {
+          ]);
+        } catch (Exception $e) {
           throw new CiviCRM_API3_Exception(
             E::ts('Error getting Invoice generation setting %1', [1 => $e->getMessage()]),
             'qbo_invoice_creation'
@@ -690,12 +711,11 @@ class CRM_Civiquickbooks_Invoice {
         }
       }
       try {
-        $customMemo = civicrm_api3('Setting', 'getvalue', array(
+        $customMemo = civicrm_api3('Setting', 'getvalue', [
           'name' => 'quickbooks_customer_memo',
           'group' => 'QuickBooks Online Settings',
-        ));
-      }
-      catch (Exception $e) {
+        ]);
+      } catch (Exception $e) {
         throw new CiviCRM_API3_Exception(
           E::ts('Error getting Invoice generation setting %1', [1 => $e->getMessage()]),
           'qbo_invoice_creation'
@@ -716,21 +736,19 @@ class CRM_Civiquickbooks_Invoice {
           if (is_array($result)) {
             $new_invoice['TxnTaxDetail'] = $result;
           }
-        }
-        catch (\QuickbooksOnline\API\Exception\IdsException $e) {
+        } catch (\QuickbooksOnline\API\Exception\IdsException $e) {
           // Error handling was doing nothing before, so keep doing nothing.
         }
       }
 
       // Ensure HTML entities are not double encoded in Invoice create
       array_walk_recursive($new_invoice, function (&$item) {
-          $item = html_entity_decode($item, (ENT_QUOTES | ENT_HTML401), 'UTF-8');
+        $item = html_entity_decode($item, (ENT_QUOTES | ENT_HTML401), 'UTF-8');
       });
 
       try {
         return \QuickBooksOnline\API\Facades\Invoice::create($new_invoice);
-      }
-      catch(Exception $e) {
+      } catch (Exception $e) {
         throw new CiviCRM_API3_Exception(
           E::ts('Error creating Invoice for %1: %2', [1 => $contributionID, 2 => $e->getMessage()]),
           'qbo_invoice_creation'
@@ -752,14 +770,14 @@ class CRM_Civiquickbooks_Invoice {
   public static function getItem($name) {
     $items =& \Civi::$statics[__CLASS__][__FUNCTION__];
 
-    if(!isset($items[$name])) {
+    if (!isset($items[$name])) {
       $field = (strpos($name, ':') === FALSE) ? 'Name' : 'FullyQualifiedName';
       $query = sprintf('SELECT %1$s,Id From Item WHERE %1$s = \'%2$s\'', $field, $name);
 
-      $dataService= CRM_Quickbooks_APIHelper::getAccountingDataServiceObject();
-      $result = $dataService->Query($query,0,1);
+      $dataService = CRM_Quickbooks_APIHelper::getAccountingDataServiceObject();
+      $result = $dataService->Query($query, 0, 1);
 
-      if(empty($result)) {
+      if (empty($result)) {
         throw new Exception("No Product found matching $name");
       }
 
@@ -781,17 +799,17 @@ class CRM_Civiquickbooks_Invoice {
   public static function getTaxCode($name) {
     $codes =& \Civi::$statics[__CLASS__][__FUNCTION__];
 
-    if(empty($name)) {
+    if (empty($name)) {
       return FALSE;
     }
 
-    if(!isset($codes[$name])) {
+    if (!isset($codes[$name])) {
       $query = sprintf('SELECT Name,Id From TaxCode WHERE Name = \'%1s\'', $name);
 
-      $dataService= CRM_Quickbooks_APIHelper::getAccountingDataServiceObject();
-      $result = $dataService->Query($query,0,1);
+      $dataService = CRM_Quickbooks_APIHelper::getAccountingDataServiceObject();
+      $result = $dataService->Query($query, 0, 1);
 
-      if(empty($result)) {
+      if (empty($result)) {
         throw new Exception("No Tax Code found matching $name");
       }
 
@@ -810,13 +828,13 @@ class CRM_Civiquickbooks_Invoice {
    * @return array
    */
   protected function mapCancelled($accounts_invoice_id, $SyncToken) {
-    $newInvoice = array();
+    $newInvoice = [];
 
     if (isset($SyncToken) && isset($accounts_invoice_id)) {
-      $newInvoice += array(
+      $newInvoice += [
         'Id' => $accounts_invoice_id,
         'SyncToken' => $SyncToken,
-      );
+      ];
     }
 
     $newInvoice = \QuickBooksOnline\API\Facades\Invoice::create($newInvoice);
@@ -870,11 +888,11 @@ class CRM_Civiquickbooks_Invoice {
       return FALSE;
     }
 
-    $tax_detail = array(
-      'TxnTaxCodeRef' => array(
+    $tax_detail = [
+      'TxnTaxCodeRef' => [
         'value' => $result[0]->Id,
-      ),
-    );
+      ],
+    ];
 
     return $tax_detail;
   }
@@ -893,16 +911,16 @@ class CRM_Civiquickbooks_Invoice {
    * @throws \CiviCRM_API3_Exception
    */
   protected function findPushContributions($params, $limit) {
-    $criteria = array(
+    $criteria = [
       'accounts_needs_update' => 1,
       'plugin' => $this->plugin,
       'connector_id' => 0,
-      'accounts_status_id' => array('NOT IN', 3),
-      'options' => array(
+      'accounts_status_id' => ['NOT IN', 3],
+      'options' => [
         'sort' => 'error_data ASC',
         'limit' => $limit,
-      ),
-    );
+      ],
+    ];
     if (isset($params['contribution_id'])) {
       $criteria['contribution_id'] = $params['contribution_id'];
       unset($criteria['accounts_needs_update']);
@@ -911,7 +929,7 @@ class CRM_Civiquickbooks_Invoice {
     $records = civicrm_api3('AccountInvoice', 'get', $criteria);
 
     if (!isset($params['contribution_id'])) {
-      $criteria['accounts_status_id'] = array('IS NULL' => 1);
+      $criteria['accounts_status_id'] = ['IS NULL' => 1];
 
       $nullrec = civicrm_api3('AccountInvoice', 'get', $criteria);
       $records['values'] = array_merge($records['values'], $nullrec['values']);
@@ -921,18 +939,18 @@ class CRM_Civiquickbooks_Invoice {
   }
 
   protected function findPullContributions($params, $limit) {
-    $criteria = array(
+    $criteria = [
       'plugin' => $this->plugin,
       'connector_id' => 0,
-      'accounts_status_id' => array('NOT IN', array(1, 3)),
-      'accounts_invoice_id' => array('IS NOT NULL' => 1),
-      'accounts_data' => array('IS NOT NULL' => 1),
-      'error_data' => array('IS NULL' => 1),
-      'options' => array(
+      'accounts_status_id' => ['NOT IN', [1, 3]],
+      'accounts_invoice_id' => ['IS NOT NULL' => 1],
+      'accounts_data' => ['IS NOT NULL' => 1],
+      'error_data' => ['IS NULL' => 1],
+      'options' => [
         'sort' => 'error_data',
         'limit' => $limit,
-      ),
-    );
+      ],
+    ];
     if (isset($params['contribution_id'])) {
       $criteria['contribution_id'] = $params['contribution_id'];
       unset($criteria['accounts_needs_update']);
@@ -941,7 +959,7 @@ class CRM_Civiquickbooks_Invoice {
     $records = civicrm_api3('AccountInvoice', 'get', $criteria);
 
     if (!isset($params['contribution_id'])) {
-      $criteria['accounts_status_id'] = array('IS NULL' => 1);
+      $criteria['accounts_status_id'] = ['IS NULL' => 1];
 
       $nullrec = civicrm_api3('AccountInvoice', 'get', $criteria);
       $records['values'] = array_merge($records['values'], $nullrec['values']);

--- a/CRM/Civiquickbooks/Upgrader.php
+++ b/CRM/Civiquickbooks/Upgrader.php
@@ -10,132 +10,38 @@ class CRM_Civiquickbooks_Upgrader extends CRM_Civiquickbooks_Upgrader_Base {
   // upgrade tasks. They are executed in order (like Drupal's hook_update_N).
 
   /**
-   * Example: Run an external SQL script when the module is installed.
-   *
-  public function install() {
-    $this->executeSqlFile('sql/myinstall.sql');
-  }
-
-  /**
    * Example: Work with entities usually not available during the install step.
    *
    * This method can be used for any post-install tasks. For example, if a step
    * of your installation depends on accessing an entity that is itself
    * created during the installation (e.g., a setting or a managed entity), do
    * so here to avoid order of operation problems.
-   *
+   */
   public function postInstall() {
-    $customFieldId = civicrm_api3('CustomField', 'getvalue', array(
-      'return' => array("id"),
-      'name' => "customFieldCreatedViaManagedHook",
-    ));
-    civicrm_api3('Setting', 'create', array(
-      'myWeirdFieldSetting' => array('id' => $customFieldId, 'weirdness' => 1),
-    ));
+    $this->createTags();
   }
 
-  /**
-   * Example: Run an external SQL script when the module is uninstalled.
-   *
-  public function uninstall() {
-   $this->executeSqlFile('sql/myuninstall.sql');
-  }
-
-  /**
-   * Example: Run a simple query when a module is enabled.
-   *
-  public function enable() {
-    CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 1 WHERE bar = "whiz"');
-  }
-
-  /**
-   * Example: Run a simple query when a module is disabled.
-   *
-  public function disable() {
-    CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 0 WHERE bar = "whiz"');
-  }
-
-  /**
-   * Example: Run a couple simple queries.
-   *
-   * @return TRUE on success
-   * @throws Exception
-   *
-  public function upgrade_4200() {
-    $this->ctx->log->info('Applying update 4200');
-    CRM_Core_DAO::executeQuery('UPDATE foo SET bar = "whiz"');
-    CRM_Core_DAO::executeQuery('DELETE FROM bang WHERE willy = wonka(2)');
-    return TRUE;
-  } // */
-
-
-  /**
-   * Example: Run an external SQL script.
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4201() {
-    $this->ctx->log->info('Applying update 4201');
-    // this path is relative to the extension base dir
-    $this->executeSqlFile('sql/upgrade_4201.sql');
-    return TRUE;
-  } // */
-
-
-  /**
-   * Example: Run a slow upgrade process by breaking it up into smaller chunk.
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4202() {
-    $this->ctx->log->info('Planning update 4202'); // PEAR Log interface
-
-    $this->addTask(E::ts('Process first step'), 'processPart1', $arg1, $arg2);
-    $this->addTask(E::ts('Process second step'), 'processPart2', $arg3, $arg4);
-    $this->addTask(E::ts('Process second step'), 'processPart3', $arg5);
-    return TRUE;
-  }
-  public function processPart1($arg1, $arg2) { sleep(10); return TRUE; }
-  public function processPart2($arg3, $arg4) { sleep(10); return TRUE; }
-  public function processPart3($arg5) { sleep(10); return TRUE; }
-  // */
-
-
-  /**
-   * Example: Run an upgrade with a query that touches many (potentially
-   * millions) of records by breaking it up into smaller chunks.
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4203() {
-    $this->ctx->log->info('Planning update 4203'); // PEAR Log interface
-
-    $minId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(min(id),0) FROM civicrm_contribution');
-    $maxId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(max(id),0) FROM civicrm_contribution');
-    for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
-      $endId = $startId + self::BATCH_SIZE - 1;
-      $title = E::ts('Upgrade Batch (%1 => %2)', array(
-        1 => $startId,
-        2 => $endId,
-      ));
-      $sql = '
-        UPDATE civicrm_contribution SET foobar = whiz(wonky()+wanker)
-        WHERE id BETWEEN %1 and %2
-      ';
-      $params = array(
-        1 => array($startId, 'Integer'),
-        2 => array($endId, 'Integer'),
-      );
-      $this->addTask($title, 'executeSql', $sql, $params);
+  private function createTags() {
+    if (empty(\Civi\Api4\Tag::get(FALSE)
+      ->addWhere('name', '=', 'Quickbooks Sync Error')
+      ->execute()->count())) {
+      \Civi\Api4\Tag::create(FALSE)
+        ->addValue('is_reserved', TRUE)
+        ->addValue('name', 'Quickbooks Sync Error')
+        ->execute();
     }
-    return TRUE;
-  } // */
+  }
 
   public function upgrade_20203() {
     $this->ctx->log->info('Setting default email preference to "Never" for compatibility.');
-
     civicrm_api3('Setting', 'create', [ 'quickbooks_email_invoice' => 'never' ]);
-
-    return true;
+    return TRUE;
   }
+
+  public function upgrade_20204() {
+    $this->ctx->log->info('Adding "Quickbooks Sync Error" tag.');
+    $this->createTags();
+    return TRUE;
+  }
+
 }

--- a/CRM/Quickbooks/APIHelper.php
+++ b/CRM/Quickbooks/APIHelper.php
@@ -235,6 +235,28 @@ class CRM_Quickbooks_APIHelper {
   }
 
   /**
+   * Check if the API credentials are authorized.
+   *
+   * @return bool
+   * @throws \Exception
+   */
+  public static function isAuthorized() {
+    $QBCredentials = CRM_Quickbooks_APIHelper::getQuickBooksCredentials();
+    if (empty($QBCredentials['accessToken'])) {
+      return FALSE;
+    }
+    if (empty($QBCredentials['refreshToken'])) {
+      return FALSE;
+    }
+
+    if (self::isTokenExpired($QBCredentials, TRUE)) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
    * Helper Function to convert faults errors saved by the SDK into something
    *   we can store in an Account* error_data
    *

--- a/CRM/Quickbooks/APIHelper.php
+++ b/CRM/Quickbooks/APIHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+use QuickBooksOnline\API\Core\HttpClients\FaultHandler;
+
 class CRM_Quickbooks_APIHelper {
 
   private static $quickBooksDataService = NULL; //Data service object for login
@@ -232,8 +234,14 @@ class CRM_Quickbooks_APIHelper {
     return $isTokenExpired;
   }
 
-  /* Helper Function to convert faults errors saved by the SDK into something
-     we can store in an Account* error_data */
+  /**
+   * Helper Function to convert faults errors saved by the SDK into something
+   *   we can store in an Account* error_data
+   *
+   * @param FaultHandler $error_response
+   *
+   * @return array|string[]
+   */
   public static function parseErrorResponse($error_response) {
     // Start with a blank set of error messages.
     $error_message = [];

--- a/api/v3/Civiquickbooks/Contactpull.php
+++ b/api/v3/Civiquickbooks/Contactpull.php
@@ -29,6 +29,10 @@ function _civicrm_api3_civiquickbooks_Contactpull_spec(&$spec) {
  * @see civicrm_api3_create_error
  */
 function civicrm_api3_civiquickbooks_Contactpull($params) {
+  if (!CRM_Quickbooks_APIHelper::isAuthorized()) {
+    throw new CiviCRM_API3_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
+  }
+
   $quickbooks = new CRM_Civiquickbooks_Contact();
   $result = $quickbooks->pull($params);
 

--- a/api/v3/Civiquickbooks/Contactpush.php
+++ b/api/v3/Civiquickbooks/Contactpush.php
@@ -23,6 +23,10 @@ function _civicrm_api3_civiquickbooks_ContactPush_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_civiquickbooks_ContactPush($params) {
+  if (!CRM_Quickbooks_APIHelper::isAuthorized()) {
+    throw new CiviCRM_API3_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
+  }
+
   $options = _civicrm_api3_get_options_from_params($params);
 
   $quickbooks = new CRM_Civiquickbooks_Contact();

--- a/api/v3/Civiquickbooks/Invoicepull.php
+++ b/api/v3/Civiquickbooks/Invoicepull.php
@@ -29,9 +29,13 @@ function _civicrm_api3_civiquickbooks_InvoicePull_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_civiquickbooks_InvoicePull($params) {
+  if (!CRM_Quickbooks_APIHelper::isAuthorized()) {
+    throw new CiviCRM_API3_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
+  }
+
   $options = _civicrm_api3_get_options_from_params($params);
 
-  $quickbooks = new CRM_Civiquickbooks_Invoice($params);
+  $quickbooks = new CRM_Civiquickbooks_Invoice();
   $result = $quickbooks->pull($params, $options['limit']);
 
   return civicrm_api3_create_success($result, $params, 'Civiquickbooks', 'Invoicepull');

--- a/api/v3/Civiquickbooks/Invoicepush.php
+++ b/api/v3/Civiquickbooks/Invoicepush.php
@@ -29,9 +29,13 @@ function _civicrm_api3_civiquickbooks_InvoicePush_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_civiquickbooks_InvoicePush($params) {
+  if (!CRM_Quickbooks_APIHelper::isAuthorized()) {
+    throw new CiviCRM_API3_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
+  }
+
   $options = _civicrm_api3_get_options_from_params($params);
 
-  $quickbooks = new CRM_Civiquickbooks_Invoice($params);
+  $quickbooks = new CRM_Civiquickbooks_Invoice();
   $result = $quickbooks->push($params, $options['limit']);
 
   return civicrm_api3_create_success($result, $params, 'Civiquickbooks', 'Invoicepush');


### PR DESCRIPTION
* Code cleanup
* We are only using the error message for logging, if it's already json_encoded we don't need to decode it just to re-encode it (was causing logs to print Array in some cases)
* Improve performance and error logging for Contact Push
* Check we are authorized before running push/pull jobs via API
* Improve logging and switch to supported API function in Invoice
* Add 'Quickbooks Sync Error' tag when contact push sync fails