### PR TITLE
Code cleanup and bug fixes

### DIFF
--- a/CRM/Civiquickbooks/Contact.php
+++ b/CRM/Civiquickbooks/Contact.php
@@ -54,7 +54,6 @@ class CRM_Civiquickbooks_Contact {
             break;
         }
 
-
         if(empty($contact))
           continue;
 
@@ -119,7 +118,7 @@ class CRM_Civiquickbooks_Contact {
       if(in_array($contact->Id, $skip_list))
         continue;
 
-      $account_contact = array(
+      $account_contact = [
         'accounts_display_name' => $contact->DisplayName,
         // AccountSync API can not parse this date format correctly, if we use the DAO directly, it has no problem.
         // 'accounts_modified_date' => date('Y-m-d H:i:s', strtotime($contact['MetaData']['LastUpdatedTime'])),
@@ -129,14 +128,14 @@ class CRM_Civiquickbooks_Contact {
         'accounts_needs_update' => 0,
         'sequential' => 1,
         'error_data' => 'NULL',
-      );
+      ];
 
       try {
-        $account_contact['id']= civicrm_api3('account_contact', 'getvalue', array(
+        $account_contact['id']= civicrm_api3('account_contact', 'getvalue', [
           'accounts_contact_id' => $contact->Id,
           'plugin' => $this->plugin,
           'return' => 'id',
-        ));
+        ]);
       } catch (CiviCRM_API3_Exception $e) {
         // No existing AccountContact found; the following API call will create one.
         // Future CIVIQBO-60 entry point for preemptive deduplication.
@@ -442,7 +441,7 @@ class CRM_Civiquickbooks_Contact {
 
 
   protected function mapToCustomer($contact, $accountsID, $customer_data) {
-    $customer = array(
+    $customer = [
       "BillAddr"           => self::getBillingAddr($contact),
       "Title"              => $contact['individual_prefix'],
       "GivenName"          => $contact['first_name'],
@@ -452,13 +451,13 @@ class CRM_Civiquickbooks_Contact {
       "FullyQualifiedName" => $contact['display_name'],
       "CompanyName"        => $contact['organization_name'],
       "DisplayName"        => $contact['display_name'],
-      "PrimaryPhone"       => array(
+      "PrimaryPhone"       => [
         "FreeFormNumber" => self::getBillingPhone($contact),
-      ),
-      "PrimaryEmailAddr"   => array(
+      ],
+      "PrimaryEmailAddr"   => [
         "Address"        => self::getBillingEmail($contact),
-      ),
-    );
+      ],
+    ];
 
     // This sets the company name field for Individuals to be their current
     // employer (if the contact has a current employer). Presumbably contacts of

--- a/CRM/Civiquickbooks/Form/Settings.php
+++ b/CRM/Civiquickbooks/Form/Settings.php
@@ -9,16 +9,16 @@ use CRM_Civiquickbooks_ExtensionUtil as E;
  */
 class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
 
-  private $_settingFilter = array('group' => 'civiquickbooks');
+  private $_settingFilter = ['group' => 'civiquickbooks'];
 
   // Form re-used from CiviXero
-  private $_submittedValues = array();
+  private $_submittedValues = [];
 
-  private $_settings = array();
+  private $_settings = [];
 
   public function buildQuickForm() {
     $settings = $this->getFormSettings();
-    $description = array();
+    $description = [];
 
     $QBCredentials = CRM_Quickbooks_APIHelper::getQuickBooksCredentials();
 
@@ -27,10 +27,10 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
         $add = 'add' . $setting['quick_form_type'];
 
         if ($add == 'addElement') {
-          $this->$add($setting['html_type'], $name, $setting['title'], CRM_Utils_Array::value('html_attributes', $setting, array()));
+          $this->$add($setting['html_type'], $name, $setting['title'], CRM_Utils_Array::value('html_attributes', $setting, []));
         }
         elseif ($setting['html_type'] == 'Select') {
-          $optionValues = array();
+          $optionValues = [];
           if (!empty($setting['pseudoconstant']) && !empty($setting['pseudoconstant']['optionGroupName'])) {
             $optionValues = CRM_Core_OptionGroup::values($setting['pseudoconstant']['optionGroupName'], FALSE, FALSE, FALSE, NULL, 'name');
           }
@@ -49,13 +49,13 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
       }
     }
 
-    $this->addButtons(array(
-      array(
+    $this->addButtons([
+      [
         'type' => 'submit',
         'name' => ts('Submit'),
         'isDefault' => TRUE,
-      ),
-    ));
+      ],
+    ]);
 
     $exdate_element = $this->_elements[$this->_elementIndex['quickbooks_access_token_expiryDate']];
     $exdate_element->freeze();
@@ -107,7 +107,7 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
     // auto-rendered in the loop -- such as "qfKey" and "buttons". These
     // items don't have labels. We'll identify renderable by filtering on
     // the 'label'.
-    $elementNames = array();
+    $elementNames = [];
     foreach ($this->_elements as $element) {
       $label = $element->getLabel();
       if (!empty($label)) {
@@ -124,9 +124,9 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
    */
   public function getFormSettings() {
     if (empty($this->_settings)) {
-      $settings = civicrm_api3('setting', 'getfields', array('filters' => $this->_settingFilter));
+      $settings = civicrm_api3('setting', 'getfields', ['filters' => $this->_settingFilter]);
     }
-    $extraSettings = civicrm_api3('setting', 'getfields', array('filters' => array('group' => 'accountsync')));
+    $extraSettings = civicrm_api3('setting', 'getfields', ['filters' => ['group' => 'accountsync']]);
     $settings = $settings['values'] + $extraSettings['values'];
     return $settings;
   }
@@ -159,13 +159,13 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
     if ($clientIDChanged || $clientSecretChanged) {
       // invalidate anything that depended on the old Client ID or Shared Secret
       civicrm_api3(
-        'setting', 'create', array(
+        'setting', 'create', [
           "quickbooks_access_token" => '',
           "quickbooks_refresh_token" => '',
           "quickbooks_realmId" => '',
           "quickbooks_access_token_expiryDate" => '',
           "quickbooks_refresh_token_expiryDate" => '',
-        )
+        ]
       );
     }
 
@@ -178,8 +178,8 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
    * @see CRM_Core_Form::setDefaultValues()
    */
   public function setDefaultValues() {
-    $existing = civicrm_api3('setting', 'get', array('return' => array_keys($this->getFormSettings())));
-    $defaults = array();
+    $existing = civicrm_api3('setting', 'get', ['return' => array_keys($this->getFormSettings())]);
+    $defaults = [];
     $domainID = CRM_Core_Config::domainID();
     foreach ($existing['values'][$domainID] as $name => $value) {
       $defaults[$name] = $value;

--- a/CRM/Civiquickbooks/Form/Settings.php
+++ b/CRM/Civiquickbooks/Form/Settings.php
@@ -153,8 +153,8 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
     civicrm_api3('setting', 'create', $values);
 
     $previousCredentials = CRM_Quickbooks_APIHelper::getQuickBooksCredentials();
-    $clientIDChanged = $previousCredentials['clientID'] != $settings['quickbooks_consumer_key'];
-    $clientSecretChanged = $previousCredentials['clientSecret'] != $settings['quickbooks_shared_secret'];
+    $clientIDChanged = $previousCredentials['clientID'] !== $values['quickbooks_consumer_key'];
+    $clientSecretChanged = $previousCredentials['clientSecret'] !== $values['quickbooks_shared_secret'];
 
     if ($clientIDChanged || $clientSecretChanged) {
       // invalidate anything that depended on the old Client ID or Shared Secret

--- a/CRM/Civiquickbooks/Job/job.mgd.php
+++ b/CRM/Civiquickbooks/Job/job.mgd.php
@@ -4,12 +4,12 @@
 // database as appropriate. For more details, see "hook_civicrm_managed" at:
 // http://wiki.civicrm.org/confluence/display/CRMDOC42/Hook+Reference
 
-return array(
-  0 => array(
+return [
+  0 => [
     'name' => 'Civiquickbooks Contact Push Job',
     'entity' => 'Job',
     'update' => 'never',
-    'params' => array(
+    'params' => [
       'version' => 3,
       'name' => 'Civiquickbooks Contact Push Job',
       'description' => 'Push updated contacts to Quickbooks',
@@ -17,13 +17,13 @@ return array(
       'api_action' => 'Contactpush',
       'run_frequency' => 'Always',
       'parameters' => '',
-    ),
-  ),
-  1 => array(
+    ],
+  ],
+  1 => [
     'name' => 'Civiquickbooks Contact Pull Job',
     'entity' => 'Job',
     'update' => 'never',
-    'params' => array(
+    'params' => [
       'version' => 3,
       'name' => 'Civiquickbooks Contact Pull Job',
       'description' => 'Pull updated contacts from Civiquickbooks',
@@ -31,13 +31,13 @@ return array(
       'api_action' => 'Contactpull',
       'run_frequency' => 'Always',
       'parameters' => "start_date=yesterday",
-    ),
-  ),
-  2 => array(
+    ],
+  ],
+  2 => [
     'name' => 'Civiquickbooks Invoice Push Job',
     'entity' => 'Job',
     'update' => 'never',
-    'params' => array(
+    'params' => [
       'version' => 3,
       'name' => 'Civiquickbooks Invoice Push Job',
       'description' => 'Push updated invoices to Quickbooks',
@@ -45,13 +45,13 @@ return array(
       'api_action' => 'Invoicepush',
       'run_frequency' => 'Always',
       'parameters' => '',
-    ),
-  ),
-  3 => array(
+    ],
+  ],
+  3 => [
     'name' => 'Civiquickbooks Invoice Pull Job',
     'entity' => 'Job',
     'update' => 'never',
-    'params' => array(
+    'params' => [
       'version' => 3,
       'name' => 'Civiquickbooks Invoice Pull Job',
       'description' => 'Pull updated invoices from Quickbooks',
@@ -59,6 +59,6 @@ return array(
       'api_action' => 'Invoicepull',
       'run_frequency' => 'Always',
       'parameters' => '',
-    ),
-  ),
-);
+    ],
+  ],
+];

--- a/CRM/Civiquickbooks/Page/AJAX.php
+++ b/CRM/Civiquickbooks/Page/AJAX.php
@@ -6,13 +6,13 @@ class CRM_Civiquickbooks_Page_AJAX extends CRM_Core_Page {
    * Function to get contact sync errors by id
    */
   public static function contactSyncErrors() {
-    $syncerrors = array();
+    $syncerrors = [];
     if (CRM_Utils_Array::value('quickbookserrorid', $_REQUEST)) {
       $quickbookserrorid = CRM_Utils_Type::escape($_REQUEST['quickbookserrorid'], 'Integer');
-      $accountcontact = civicrm_api3("AccountContact", "get", array(
+      $accountcontact = civicrm_api3("AccountContact", "get", [
         "id"          => $quickbookserrorid ,
         "sequential" => TRUE,
-      ));
+      ]);
       if ($accountcontact["count"]) {
         $accountcontact = $accountcontact["values"][0];
         $syncerrors = $accountcontact["error_data"];
@@ -27,7 +27,7 @@ class CRM_Civiquickbooks_Page_AJAX extends CRM_Core_Page {
    *
    */
   public static function invoiceSyncErrors() {
-    $syncerrors = array();
+    $syncerrors = [];
     if (CRM_Utils_Array::value('quickbookserrorid', $_REQUEST)) {
       $contactid = CRM_Utils_Type::escape($_REQUEST['quickbookserrorid'], 'Integer');
       $contributions = _civiquickbooks_getContactContributions($contactid);

--- a/CRM/Civiquickbooks/Page/Inline/ContactSyncErrors.php
+++ b/CRM/Civiquickbooks/Page/Inline/ContactSyncErrors.php
@@ -20,11 +20,11 @@ class CRM_Civiquickbooks_Page_Inline_ContactSyncErrors extends CRM_Core_Page {
     $hasContactErrors = FALSE;
 
     try{
-      $account_contact = civicrm_api3('account_contact', 'getsingle', array(
+      $account_contact = civicrm_api3('account_contact', 'getsingle', [
         'contact_id' => $contactID,
         'return'     => 'accounts_contact_id, accounts_needs_update, connector_id, error_data, id, contact_id',
         'plugin'     => _civiquickbooks_account_plugin_name(),
-      ));
+      ]);
 
       $page->assign('accountContactId', $account_contact['id']);
 

--- a/CRM/Civiquickbooks/Page/Inline/ContactSyncStatus.php
+++ b/CRM/Civiquickbooks/Page/Inline/ContactSyncStatus.php
@@ -20,11 +20,11 @@ class CRM_Civiquickbooks_Page_Inline_ContactSyncStatus extends CRM_Core_Page {
     $syncStatus = 0;
 
     try{
-      $account_contact = civicrm_api3('account_contact', 'getsingle', array(
+      $account_contact = civicrm_api3('account_contact', 'getsingle', [
         'contact_id' => $contactID,
         'return'     => 'accounts_contact_id, accounts_needs_update, connector_id, error_data, id, contact_id',
         'plugin'     => _civiquickbooks_account_plugin_name(),
-      ));
+      ]);
 
       if (!empty($account_contact['accounts_contact_id'])) {
         $syncStatus = 1;

--- a/CRM/Civiquickbooks/Page/Inline/InvoiceSyncErrors.php
+++ b/CRM/Civiquickbooks/Page/Inline/InvoiceSyncErrors.php
@@ -20,11 +20,11 @@ class CRM_Civiquickbooks_Page_Inline_InvoiceSyncErrors extends CRM_Core_Page {
     $hasInvoiceErrors = FALSE;
 
     try{
-      $account_contact = civicrm_api3('account_contact', 'getsingle', array(
+      $account_contact = civicrm_api3('account_contact', 'getsingle', [
         'contact_id' => $contactID,
         'return'     => 'accounts_contact_id, accounts_needs_update, connector_id, error_data, id, contact_id',
         'plugin'     => _civiquickbooks_account_plugin_name(),
-      ));
+      ]);
 
       $page->assign('accountContactId', $account_contact['id']);
 

--- a/CRM/Civiquickbooks/Page/OAuthQBO.php
+++ b/CRM/Civiquickbooks/Page/OAuthQBO.php
@@ -44,8 +44,8 @@ class CRM_Civiquickbooks_Page_OAuthQBO extends CRM_Core_Page {
 
   public function run() {
     //get current value in the database
-    $this->consumer_key = civicrm_api3('Setting', 'getvalue', array('name' => "quickbooks_consumer_key"));
-    $this->shared_secret = civicrm_api3('Setting', 'getvalue', array('name' => "quickbooks_shared_secret"));
+    $this->consumer_key = civicrm_api3('Setting', 'getvalue', ['name' => "quickbooks_consumer_key"]);
+    $this->shared_secret = civicrm_api3('Setting', 'getvalue', ['name' => "quickbooks_shared_secret"]);
 
     //the initial value of Client ID and Client Secret is empty string, need to check if they have been set
     if ($this->consumer_key === 0 || $this->consumer_key == '' || !isset($this->consumer_key)) {
@@ -59,7 +59,7 @@ class CRM_Civiquickbooks_Page_OAuthQBO extends CRM_Core_Page {
 
     // Check if its a request from QuickBooks after redirection.
     if (isset($_GET['state']) && isset($_GET['code']) && isset($_GET['realmId'])) {
-      $stateToken = civicrm_api3('Setting', 'getvalue', array('name' => "quickbooks_state_token"));;
+      $stateToken = civicrm_api3('Setting', 'getvalue', ['name' => "quickbooks_state_token"]);;
       $state = $_GET['state'];
       $state = json_decode($state, TRUE);
 
@@ -89,13 +89,13 @@ class CRM_Civiquickbooks_Page_OAuthQBO extends CRM_Core_Page {
           $tokenExpiresIn = DateTime::createFromFormat('Y/m/d H:i:s', $tokenExpiresIn);
 
           // Save all the required settings.
-          civicrm_api3('Setting', 'create', array(
+          civicrm_api3('Setting', 'create', [
             'quickbooks_access_token' => $accessToken,
             'quickbooks_refresh_token' => $refreshToken,
             'quickbooks_realmId' => $realmId,
             'quickbooks_access_token_expiryDate' => $tokenExpiresIn->format("Y-m-d H:i:s"),
             'quickbooks_refresh_token_expiryDate' => $refreshTokenExpiresIn->format("Y-m-d H:i:s"),
-          ));
+          ]);
 
           // Get Data service object for accounting ( Including Access & Refresh token plus realmId)
           $dataService = CRM_Quickbooks_APIHelper::getAccountingDataServiceObject();
@@ -111,33 +111,33 @@ class CRM_Civiquickbooks_Page_OAuthQBO extends CRM_Core_Page {
           $_company_country = (isset($_company_country['CompanyInfo'])) ? $_company_country['CompanyInfo']['Country'] : 'AU';
 
           try {
-            civicrm_api3('Setting', 'create', array('quickbooks_company_country' => $_company_country));
+            civicrm_api3('Setting', 'create', ['quickbooks_company_country' => $_company_country]);
           } catch (CiviCRM_API3_Exception $e) {
             // Handle error here.
             $errorMessage = $e->getMessage();
             $errorCode = $e->getErrorCode();
             $errorData = $e->getExtraParams();
-            return array(
+            return [
               'error' => $errorMessage,
               'error_code' => $errorCode,
               'error_data' => $errorData,
-            );
+            ];
           }
 
           // Successfully tokens and Company details stored in database.
-          $this->output = array(
+          $this->output = [
             'message' => "Access token info retrieved and stored successfully!",
             'redirect_url' => '<a href="' . str_replace("&amp;", "&", CRM_Utils_System::url("civicrm/quickbooks/settings", NULL, TRUE, NULL)) . '">Click here to go back to CiviQuickbooks settings page to see the new expiry date of your new access token and key</a>',
-          );
+          ];
 
         } catch (\QuickBooksOnline\API\Exception\IdsException $e) {
           // Exception while interacting with QuickBooks
           // Output an error with try again message.
 
-          $this->output = array(
+          $this->output = [
             'message' => $e->getMessage(),
             'redirect_url' => '<a href="' . str_replace("&amp;", "&", CRM_Utils_System::url("civicrm/quickbooks/settings", NULL, TRUE, NULL)) . '">Click here to go back to CiviQuickbooks settings page and try again.</a>',
-          );
+          ];
         }
       }
     }
@@ -148,16 +148,16 @@ class CRM_Civiquickbooks_Page_OAuthQBO extends CRM_Core_Page {
       $error = $_GET['error'];
       if ($error == "access_denied") {
         // Output error if User denied the access.
-        $this->output = array(
+        $this->output = [
           'message' => 'You\'ve not authorize the request. Please authorize it to sync CiviCRM with QuickBooks',
           'redirect_url' => '<a href="' . str_replace("&amp;", "&", CRM_Utils_System::url("civicrm/quickbooks/settings", NULL, TRUE, NULL)) . '">Click here to go back to CiviQuickbooks settings page to authorise the Quickbooks CiviCRM App</a>',
-        );
+        ];
       }
     }
 
     // If first request without error/code, redirect user for Auth.
     if ($doRedirectForAuth) {
-      $this->output = array('message' => 'Authorizing...');
+      $this->output = ['message' => 'Authorizing...'];
       $this->redirectForAuth();
     }
 

--- a/CRM/Quickbooks/APIHelper.php
+++ b/CRM/Quickbooks/APIHelper.php
@@ -42,18 +42,18 @@ class CRM_Quickbooks_APIHelper {
     $redirectUrl = self::getRedirectUrl();
     $stateTokenValue = self::generateStateToken(40);
 
-    $clientID = civicrm_api3('Setting', 'getvalue', array('name' => "quickbooks_consumer_key"));
-    $clientSecret = civicrm_api3('Setting', 'getvalue', array('name' => "quickbooks_shared_secret"));
-    $logLocation = civicrm_api3('Setting', 'getvalue', array('name' => "quickbooks_log_dir"));
-    $logActivated = civicrm_api3('Setting', 'getvalue', array('name' => "quickbooks_activate_qbo_logging"));
+    $clientID = civicrm_api3('Setting', 'getvalue', ['name' => "quickbooks_consumer_key"]);
+    $clientSecret = civicrm_api3('Setting', 'getvalue', ['name' => "quickbooks_shared_secret"]);
+    $logLocation = civicrm_api3('Setting', 'getvalue', ['name' => "quickbooks_log_dir"]);
+    $logActivated = civicrm_api3('Setting', 'getvalue', ['name' => "quickbooks_activate_qbo_logging"]);
 
 
-    $stateToken = array(
+    $stateToken = [
       'state_token' => $stateTokenValue,
-    );
+    ];
     Civi::settings()->set('quickbooks_state_token', $stateTokenValue);
 
-    self::$quickBooksDataService = \QuickBooksOnline\API\DataService\DataService::Configure(array(
+    self::$quickBooksDataService = \QuickBooksOnline\API\DataService\DataService::Configure([
       'auth_mode' => 'oauth2',
       'ClientID' => $clientID,
       'ClientSecret' => $clientSecret,
@@ -61,7 +61,7 @@ class CRM_Quickbooks_APIHelper {
       'scope' => "com.intuit.quickbooks.accounting",
       'response_type' => 'code',
       'state' => json_encode($stateToken),
-  ));
+    ]);
 
     self::$quickBooksDataService->setLogLocation($logLocation);
     if (!$logActivated) {
@@ -89,11 +89,11 @@ class CRM_Quickbooks_APIHelper {
     }
 
     $QBCredentials = self::getQuickBooksCredentials();
-    $logLocation = civicrm_api3('Setting', 'getvalue', array('name' => "quickbooks_log_dir"));
-    $logActivated = civicrm_api3('Setting', 'getvalue', array('name' => "quickbooks_activate_qbo_logging"));
-    $baseUrl = civicrm_api3('Setting', 'getvalue', array('name' => "quickbooks_baseurl"));
+    $logLocation = civicrm_api3('Setting', 'getvalue', ['name' => "quickbooks_log_dir"]);
+    $logActivated = civicrm_api3('Setting', 'getvalue', ['name' => "quickbooks_activate_qbo_logging"]);
+    $baseUrl = civicrm_api3('Setting', 'getvalue', ['name' => "quickbooks_baseurl"]);
 
-    $dataServiceParams = array(
+    $dataServiceParams = [
       'auth_mode' => 'oauth2',
       'ClientID' => $QBCredentials['clientID'],
       'ClientSecret' => $QBCredentials['clientSecret'],
@@ -101,7 +101,7 @@ class CRM_Quickbooks_APIHelper {
       'refreshTokenKey' => $QBCredentials['refreshToken'],
       'QBORealmID' => $QBCredentials['realMId'],
       'baseUrl' => $baseUrl,
-    );
+    ];
 
     if ($forRefreshToken) {
       unset($dataServiceParams['accessTokenKey']);
@@ -167,12 +167,12 @@ class CRM_Quickbooks_APIHelper {
         $accessToken = $refreshedAccessTokenObj->getAccessToken();
         $refreshToken = $refreshedAccessTokenObj->getRefreshToken();
 
-        civicrm_api3('Setting', 'create', array(
+        civicrm_api3('Setting', 'create', [
           'quickbooks_access_token' => $accessToken,
           'quickbooks_refresh_token' => $refreshToken,
           'quickbooks_access_token_expiryDate' => $tokenExpiresIn->format("Y-m-d H:i:s"),
           'quickbooks_refresh_token_expiryDate' => $refreshTokenExpiresIn->format("Y-m-d H:i:s"),
-        ));
+        ]);
 
       } catch (\QuickBooksOnline\API\Exception\IdsException $e) {
 
@@ -187,7 +187,7 @@ class CRM_Quickbooks_APIHelper {
    * @throws CiviCRM_API3_Exception
    */
   public static function getQuickBooksCredentials() {
-    $quickBooksSettings = civicrm_api3('Setting', 'get', array('group' => "QuickBooks Online Settings"));
+    $quickBooksSettings = civicrm_api3('Setting', 'get', ['group' => "QuickBooks Online Settings"]);
     $quickBooksSettings = $quickBooksSettings['values'][$quickBooksSettings['id']];
     $clientID = $quickBooksSettings["quickbooks_consumer_key"];
     $clientSecret = $quickBooksSettings["quickbooks_shared_secret"];
@@ -197,7 +197,7 @@ class CRM_Quickbooks_APIHelper {
     $tokenExpiryDate = $quickBooksSettings["quickbooks_access_token_expiryDate"];
     $refreshTokenExpiryDate = $quickBooksSettings["quickbooks_refresh_token_expiryDate"];
 
-    return array(
+    return [
       'clientID' => $clientID,
       'clientSecret' => $clientSecret,
       'accessToken' => $accessToken,
@@ -205,7 +205,7 @@ class CRM_Quickbooks_APIHelper {
       'realMId' => $realMId,
       'accessTokenExpiryDate' => $tokenExpiryDate,
       'refreshTokenExpiryDate' => $refreshTokenExpiryDate,
-    );
+    ];
   }
 
   /**

--- a/api/v3/Civiquickbooks/Contactpull.php
+++ b/api/v3/Civiquickbooks/Contactpull.php
@@ -10,13 +10,20 @@
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
  */
 function _civicrm_api3_civiquickbooks_Contactpull_spec(&$spec) {
-  $spec['start_date'] = array(
+  $spec['start_date'] = [
     'api.default' => 'yesterday',
     'type' => CRM_Utils_Type::T_DATE,
     'name' => 'start_date',
     'title' => 'Sync Start Date',
     'description' => 'date to start pulling from',
-  );
+  ];
+  $spec['connector_id'] = [
+    'api.default' => 0,
+    'type' => CRM_Utils_Type::T_INT,
+    'name' => 'connector_id',
+    'title' => 'Connector ID',
+    'description' => 'Connector ID if using nz.co.fuzion.connectors, else 0',
+  ];
 }
 
 /**

--- a/api/v3/Civiquickbooks/Contactpush.php
+++ b/api/v3/Civiquickbooks/Contactpush.php
@@ -10,6 +10,27 @@
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
  */
 function _civicrm_api3_civiquickbooks_ContactPush_spec(&$spec) {
+  $spec['start_date'] = [
+    'api.default' => 'yesterday',
+    'type' => CRM_Utils_Type::T_DATE,
+    'name' => 'start_date',
+    'title' => 'Sync Start Date',
+    'description' => 'date to start pushing from',
+  ];
+  $spec['connector_id'] = [
+    'api.default' => 0,
+    'type' => CRM_Utils_Type::T_INT,
+    'name' => 'connector_id',
+    'title' => 'Connector ID',
+    'description' => 'Connector ID if using nz.co.fuzion.connectors, else 0',
+  ];
+  $spec['contact_id'] = [
+    'name' => 'contact_id',
+    'title' => 'contact ID',
+    'description' => 'ID of the CiviCRM contact',
+    'api.required' => 0,
+    'type' => CRM_Utils_Type::T_INT,
+  ];
 }
 
 /**
@@ -28,14 +49,10 @@ function civicrm_api3_civiquickbooks_ContactPush($params) {
   }
 
   $options = _civicrm_api3_get_options_from_params($params);
+  $params['limit'] = $options['limit'];
 
   $quickbooks = new CRM_Civiquickbooks_Contact();
-  $output = $quickbooks->push($options['limit']);
-
-  // ALTERNATIVE: $returnValues = array(); // OK, success
-  // ALTERNATIVE: $returnValues = array("Some value"); // OK, return a single value
-
-  // Spec: civicrm_api3_create_success($values = 1, $params = array(), $entity = NULL, $action = NULL)
+  $output = $quickbooks->push($params);
 
   return civicrm_api3_create_success($output, $params, 'Civiquickbooks', 'Contactpush');
 }

--- a/api/v3/Civiquickbooks/Invoicepull.php
+++ b/api/v3/Civiquickbooks/Invoicepull.php
@@ -10,12 +10,12 @@
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
  */
 function _civicrm_api3_civiquickbooks_InvoicePull_spec(&$spec) {
-  $spec['contribution_id'] = array(
+  $spec['contribution_id'] = [
     'type' => CRM_Utils_Type::T_INT,
     'name' => 'contribution_id',
     'title' => 'Contribution ID',
     'description' => 'contribution id (optional, overrides needs_update flag)',
-  );
+  ];
 }
 
 /**

--- a/api/v3/Civiquickbooks/Invoicepush.php
+++ b/api/v3/Civiquickbooks/Invoicepush.php
@@ -10,12 +10,12 @@
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
  */
 function _civicrm_api3_civiquickbooks_InvoicePush_spec(&$spec) {
-  $spec['contribution_id'] = array(
+  $spec['contribution_id'] = [
     'type' => CRM_Utils_Type::T_INT,
     'name' => 'contribution_id',
     'title' => 'Contribution ID',
     'description' => 'contribution id (optional, overrides needs_update flag)',
-  );
+  ];
 }
 
 /**

--- a/civiquickbooks.civix.php
+++ b/civiquickbooks.civix.php
@@ -79,6 +79,13 @@ class CRM_Civiquickbooks_ExtensionUtil {
 
 use CRM_Civiquickbooks_ExtensionUtil as E;
 
+function _civiquickbooks_civix_mixin_polyfill() {
+  if (!class_exists('CRM_Extension_MixInfo')) {
+    $polyfill = __DIR__ . '/mixin/polyfill.php';
+    (require $polyfill)(E::LONG_NAME, E::SHORT_NAME, E::path());
+  }
+}
+
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
@@ -91,9 +98,9 @@ function _civiquickbooks_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {
@@ -105,19 +112,7 @@ function _civiquickbooks_civix_civicrm_config(&$config = NULL) {
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_xmlMenu().
- *
- * @param $files array(string)
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
- */
-function _civiquickbooks_civix_civicrm_xmlMenu(&$files) {
-  foreach (_civiquickbooks_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
+  _civiquickbooks_civix_mixin_polyfill();
 }
 
 /**
@@ -130,6 +125,7 @@ function _civiquickbooks_civix_civicrm_install() {
   if ($upgrader = _civiquickbooks_civix_upgrader()) {
     $upgrader->onInstall();
   }
+  _civiquickbooks_civix_mixin_polyfill();
 }
 
 /**
@@ -170,6 +166,7 @@ function _civiquickbooks_civix_civicrm_enable() {
       $upgrader->onEnable();
     }
   }
+  _civiquickbooks_civix_mixin_polyfill();
 }
 
 /**
@@ -215,136 +212,6 @@ function _civiquickbooks_civix_upgrader() {
   else {
     return CRM_Civiquickbooks_Upgrader_Base::instance();
   }
-}
-
-/**
- * Search directory tree for files which match a glob pattern.
- *
- * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
- * for backward compatibility of extension code that uses it.
- *
- * @param string $dir base dir
- * @param string $pattern , glob pattern, eg "*.txt"
- *
- * @return array
- */
-function _civiquickbooks_civix_find_files($dir, $pattern) {
-  return CRM_Utils_File::findFiles($dir, $pattern);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_managed().
- *
- * Find any *.mgd.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
- */
-function _civiquickbooks_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _civiquickbooks_civix_find_files(__DIR__, '*.mgd.php');
-  sort($mgdFiles);
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-      $entities[] = $e;
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_caseTypes().
- *
- * Find any and return any files matching "xml/case/*.xml"
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
- */
-function _civiquickbooks_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_civiquickbooks_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      throw new CRM_Core_Exception($errorMessage);
-    }
-    $caseTypes[$name] = [
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    ];
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_angularModules().
- *
- * Find any and return any files matching "ang/*.ang.php"
- *
- * Note: This hook only runs in CiviCRM 4.5+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
- */
-function _civiquickbooks_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _civiquickbooks_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
-    }
-    $angularModules[$name] = $module;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_themes().
- *
- * Find any and return any files matching "*.theme.php"
- */
-function _civiquickbooks_civix_civicrm_themes(&$themes) {
-  $files = _civiquickbooks_civix_glob(__DIR__ . '/*.theme.php');
-  foreach ($files as $file) {
-    $themeMeta = include $file;
-    if (empty($themeMeta['name'])) {
-      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
-    }
-    if (empty($themeMeta['ext'])) {
-      $themeMeta['ext'] = E::LONG_NAME;
-    }
-    $themes[$themeMeta['name']] = $themeMeta;
-  }
-}
-
-/**
- * Glob wrapper which is guaranteed to return an array.
- *
- * The documentation for glob() says, "On some systems it is impossible to
- * distinguish between empty match and an error." Anecdotally, the return
- * result for an empty match is sometimes array() and sometimes FALSE.
- * This wrapper provides consistency.
- *
- * @link http://php.net/glob
- * @param string $pattern
- *
- * @return array
- */
-function _civiquickbooks_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : [];
 }
 
 /**
@@ -426,18 +293,6 @@ function _civiquickbooks_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $pare
     if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
       _civiquickbooks_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _civiquickbooks_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
   }
 }
 

--- a/civiquickbooks.php
+++ b/civiquickbooks.php
@@ -15,16 +15,6 @@ function civiquickbooks_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_xmlMenu().
- *
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
- */
-function civiquickbooks_civicrm_xmlMenu(&$files) {
-  _civiquickbooks_civix_civicrm_xmlMenu($files);
-}
-
-/**
  * Implements hook_civicrm_install().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
@@ -77,54 +67,6 @@ function civiquickbooks_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
 }
 
 /**
- * Implements hook_civicrm_managed().
- *
- * Generate a list of entities to create/deactivate/delete when this module
- * is installed, disabled, uninstalled.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
- */
-function civiquickbooks_civicrm_managed(&$entities) {
-  _civiquickbooks_civix_civicrm_managed($entities);
-}
-
-/**
- * Implements hook_civicrm_caseTypes().
- *
- * Generate a list of case-types.
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function civiquickbooks_civicrm_caseTypes(&$caseTypes) {
-  _civiquickbooks_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
- * Implements hook_civicrm_angularModules().
- *
- * Generate a list of Angular modules.
- *
- * Note: This hook only runs in CiviCRM 4.5+. It may
- * use features only available in v4.6+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function civiquickbooks_civicrm_angularModules(&$angularModules) {
-  _civiquickbooks_civix_civicrm_angularModules($angularModules);
-}
-
-/**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function civiquickbooks_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _civiquickbooks_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_navigationMenu().
  *
  * Adds entries to the navigation menu.
@@ -174,15 +116,15 @@ function civiquickbooks_civicrm_mapAccountsData(&$accountsData, $entity, $plugin
     return;
   }
 
-  $accountsData['civicrm_formatted'] = array();
+  $accountsData['civicrm_formatted'] = [];
 
-  $mappedFields = array(
+  $mappedFields = [
     'DisplayName' => 'display_name',
     'GivenName' => 'first_name',
     'MiddleName' => 'middle_name',
     'FamilyName' => 'last_name',
     'PrimaryEmailAddr' => 'email',
-  );
+  ];
 
   /* Map primary email address */
   foreach ($mappedFields as $quickbooksField => $civicrmField) {
@@ -204,11 +146,11 @@ function civiquickbooks_civicrm_mapAccountsData(&$accountsData, $entity, $plugin
 
   /* Map Billing Address */
   if (isset($accountsData['BillAddr']) && is_array($accountsData['BillAddr'])) {
-    $addressMappedFields = array(
+    $addressMappedFields = [
       'Line1' => 'street_address',
       'City' => 'city',
       'PostalCode' => 'postal_code',
-    );
+    ];
 
     foreach ($addressMappedFields as $quickbooksField => $civicrmField) {
       if (isset($accountsData['BillAddr'][$quickbooksField])) {
@@ -218,11 +160,11 @@ function civiquickbooks_civicrm_mapAccountsData(&$accountsData, $entity, $plugin
   }
   /* Map Shipping Address */
   elseif (isset($accountsData['ShipAddr']) && is_array($accountsData['ShipAddr'])) {
-    $addressMappedFields = array(
+    $addressMappedFields = [
       'Line1' => 'street_address',
       'City' => 'city',
       'PostalCode' => 'postal_code',
-    );
+    ];
 
     foreach ($addressMappedFields as $quickbooksField => $civicrmField) {
       if (isset($accountsData['ShipAddr'][$quickbooksField])) {
@@ -257,9 +199,9 @@ function civiquickbooks_civicrm_check(&$messages) {
   if ($isRefreshTokenExpired) {
     $messages[] = (new CRM_Utils_Check_Message(
       'quickbooks_refresh_token_expired',
-      ts('QuickBooks refresh is token is expired, <a href="%1">Reauthorize QuickBooks application</a> to continue syncing contacts and contributions updates to QuickBooks.', array(
+      ts('QuickBooks refresh is token is expired, <a href="%1">Reauthorize QuickBooks application</a> to continue syncing contacts and contributions updates to QuickBooks.', [
         1 => CRM_Utils_System::url('civicrm/quickbooks/OAuth', ''),
-      )),
+      ]),
       ts('QuickBooks Token Expired'),
       \Psr\Log\LogLevel::CRITICAL,
       'fa-clock-o'
@@ -282,11 +224,11 @@ function _civiquickbooks_account_plugin_name() {
  * @param $contactid
  */
 function _civiquickbooks_getContactContributions($contactid) {
-  $contributions = civicrm_api3("Contribution", "get", array(
+  $contributions = civicrm_api3("Contribution", "get", [
     "contact_id" => $contactid,
-    "return"     => array("contribution_id"),
+    "return"     => ["contribution_id"],
     "sequential" => TRUE,
-  ));
+  ]);
   $contributions = array_column($contributions["values"], "id");
   return $contributions;
 }
@@ -297,12 +239,12 @@ function _civiquickbooks_getContactContributions($contactid) {
  * @param $contributions
  */
 function _civiquickbooks_getErroredInvoicesOfContributions($contributions) {
-  $invoices = civicrm_api3("AccountInvoice", "get", array(
+  $invoices = civicrm_api3("AccountInvoice", "get", [
     "plugin"          => _civiquickbooks_account_plugin_name(),
     "sequential"      => TRUE,
-    "contribution_id" => array("IN" => $contributions),
-    "error_data"      => array("<>" => ""),
-  ));
+    "contribution_id" => ["IN" => $contributions],
+    "error_data"      => ["<>" => ""],
+  ]);
   return $invoices;
 }
 
@@ -357,8 +299,17 @@ function civiquickbooks_civicrm_pageRun(&$page) {
     CRM_Civiquickbooks_Page_Inline_ContactSyncErrors::addContactSyncErrorsBlock($page, $contactID);
     CRM_Civiquickbooks_Page_Inline_InvoiceSyncErrors::addInvoiceSyncErrorsBlock($page, $contactID);
 
-    CRM_Core_Region::instance('contact-basic-info-right')->add(array(
+    CRM_Core_Region::instance('contact-basic-info-right')->add([
       'template' => "CRM/Civiquickbooks/ContactSyncBlock.tpl",
-    ));
+    ]);
   }
+}
+
+/**
+ * Implements hook_civicrm_entityTypes().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function civiquickbooks_civicrm_entityTypes(&$entityTypes) {
+  _civiquickbooks_civix_civicrm_entityTypes($entityTypes);
 }

--- a/info.xml
+++ b/info.xml
@@ -26,5 +26,11 @@
   <comments>Development and support for this Extension is funded solely by Agileware and CiviCRM community contributions. Agileware does not receive any funding at all for this Extension from the CiviCRM Partner program or CiviCRM LLC. Agileware welcome any funding to help continue paying Agileware staff to continue contributing to the CiviCRM community and Extensions. You can donate to Agileware using https://www.paypal.me/agileware</comments>
   <civix>
     <namespace>CRM/Civiquickbooks</namespace>
+    <format>22.05.2</format>
   </civix>
+  <mixins>
+    <mixin>menu-xml@1.0.0</mixin>
+    <mixin>mgd-php@1.0.0</mixin>
+    <mixin>setting-php@1.0.0</mixin>
+  </mixins>
 </extension>

--- a/settings/civiquickbooks.setting.php
+++ b/settings/civiquickbooks.setting.php
@@ -2,8 +2,8 @@
 
 use CRM_Civiquickbooks_ExtensionUtil as E;
 
-return array(
-  'quickbooks_consumer_key' => array(
+return [
+  'quickbooks_consumer_key' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_consumer_key',
@@ -16,12 +16,12 @@ return array(
     'description' => E::ts('Initial client id retrieved from quickbooks website'),
     'help_text' => E::ts('Initial client id retrieved from quickbooks website'),
     'html_type' => 'Text',
-    'html_attributes' => array(
+    'html_attributes' => [
       'size' => 50,
-    ),
+    ],
     'quick_form_type' => 'Element',
-  ),
-  'quickbooks_shared_secret' => array(
+  ],
+  'quickbooks_shared_secret' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_shared_secret',
@@ -34,12 +34,12 @@ return array(
     'description' => E::ts('Initial client secret retrieved from quickbooks website'),
     'help_text' => E::ts('Initial client secret retrieved from quickbooks website'),
     'html_type' => 'Text',
-    'html_attributes' => array(
+    'html_attributes' => [
       'size' => 50,
-    ),
+    ],
     'quick_form_type' => 'Element',
-  ),
-  'quickbooks_baseurl' => array(
+  ],
+  'quickbooks_baseurl' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_baseurl',
@@ -57,8 +57,8 @@ return array(
       'Development' => E::ts('Development'),
     ),
     'quick_form_type' => 'Element',
-  ),
-  'quickbooks_access_token' => array(
+  ],
+  'quickbooks_access_token' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_access_token',
@@ -71,8 +71,8 @@ return array(
     'is_contact' => 0,
     'description' => E::ts('Access token retrieved after user authorization'),
     'help_text' => E::ts('Access token retrieved after user authorization'),
-  ),
-  'quickbooks_refresh_token' => array(
+  ],
+  'quickbooks_refresh_token' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_refresh_token',
@@ -85,8 +85,8 @@ return array(
     'is_contact' => 0,
     'description' => E::ts('Refresh token retrieved after user authorization'),
     'help_text' => E::ts('Refresh token retrieved after user authorization'),
-  ),
-  'quickbooks_state_token' => array(
+  ],
+  'quickbooks_state_token' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_state_token',
@@ -99,8 +99,8 @@ return array(
     'is_contact' => 0,
     'description' => E::ts('State token generated for user authorization'),
     'help_text' => E::ts('State token generated for user authorization'),
-  ),
-  'quickbooks_access_token_expiryDate' => array(
+  ],
+  'quickbooks_access_token_expiryDate' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_access_token_expiryDate',
@@ -113,13 +113,13 @@ return array(
     'description' => E::ts('Expiry date of the current access token'),
     'help_text' => E::ts('Expiry date of the current access token'),
     'html_type' => 'Text',
-    'html_attributes' => array(
+    'html_attributes' => [
       'size' => 50,
       'readonly' => 'true',
-    ),
+    ],
     'quick_form_type' => 'Element',
-  ),
-  'quickbooks_refresh_token_expiryDate' => array(
+  ],
+  'quickbooks_refresh_token_expiryDate' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_refresh_token_expiryDate',
@@ -132,13 +132,13 @@ return array(
     'description' => E::ts('Expiry date of the current refresh token'),
     'help_text' => E::ts('Expiry date of the current refresh token'),
     'html_type' => 'Text',
-    'html_attributes' => array(
+    'html_attributes' => [
       'size' => 50,
       'readonly' => 'true',
-    ),
+    ],
     'quick_form_type' => 'Element',
-  ),
-  'quickbooks_email_invoice' => array(
+  ],
+  'quickbooks_email_invoice' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_email_invoice',
@@ -151,14 +151,14 @@ return array(
     'description' => E::ts('Whether an email should be sent to the Invoicee when a new Invoice is created in Quickbooks.'),
     'help_text' => E::ts('Whether an email should be sent to the Invoicee when a new Invoice is created in Quickbooks.'),
     'html_type' => 'Select',
-    'html_attributes' => array(
+    'html_attributes' => [
       'never' => E::ts('Never'),
       'unpaid' => E::ts('Unpaid Invoices Only'),
       'always' => E::ts('Always'),
-    ),
+    ],
     'quick_form_type' => 'Element',
-  ),
-  'quickbooks_log_dir' => array(
+  ],
+  'quickbooks_log_dir' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_log_dir',
@@ -171,12 +171,12 @@ return array(
     'description' => E::ts('Absolute path to writable file system directory for QBO logs.'),
     'help_text' => E::ts('Absolute path to writable file system directory for QBO logs.'),
     'html_type' => 'Text',
-    'html_attributes' => array(
+    'html_attributes' => [
       'size' => 30,
-    ),
+    ],
     'quick_form_type' => 'Element',
-  ),
-  'quickbooks_activate_qbo_logging' => array(
+  ],
+  'quickbooks_activate_qbo_logging' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_activate_qbo_logging',
@@ -190,8 +190,8 @@ return array(
     'help_text' => E::ts('If selected, QBO will log potentially sensitive data to the QBO Log Directory.'),
     'html_type' => 'checkbox',
     'quick_form_type' => 'Element',
-  ),
-  'quickbooks_realmId' => array(
+  ],
+  'quickbooks_realmId' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_realmId',
@@ -204,12 +204,12 @@ return array(
     'description' => E::ts('realmId retrieved when got access token'),
     'help_text' => E::ts('realmId retrieved when got access token'),
     'html_type' => 'Text',
-    'html_attributes' => array(
+    'html_attributes' => [
       'size' => 50,
       'readonly' => 'true',
-    ),
-  ),
-  'quickbooks_company_country' => array(
+    ],
+  ],
+  'quickbooks_company_country' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_company_country',
@@ -222,12 +222,12 @@ return array(
     'description' => E::ts('QuickBooks company country code for differentiating US and other countries during including tax in invoices.'),
     'help_text' => E::ts('QuickBooks company country code for differentiating US and other countries during including tax in invoices.'),
     'html_type' => 'Text',
-    'html_attributes' => array(
+    'html_attributes' => [
       'size' => 50,
       'readonly' => 'true',
-    ),
-  ),
-  'quickbooks_autogenerate_invoice_number' => array(
+    ],
+  ],
+  'quickbooks_autogenerate_invoice_number' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_autogenerate_invoice_number',
@@ -240,13 +240,13 @@ return array(
     'description' => E::ts('Whether the invoice numbers should be generated in CiviCRM or QuickBooks.'),
     'help_text' => E::ts('Whether the invoice numbers should be generated in CiviCRM or QuickBooks.'),
     'html_type' => 'Select',
-    'html_attributes' => array(
+    'html_attributes' => [
       'civi' => E::ts('CiviCRM'),
       'qb' => E::ts('QuickBooks'),
-    ),
+    ],
     'quick_form_type' => 'Element',
-  ),
-  'quickbooks_allow_ach' => array(
+  ],
+  'quickbooks_allow_ach' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_allow_ach',
@@ -259,13 +259,13 @@ return array(
     'description' => E::ts('Specifies if invoices can be paid with online bank transfers'),
     'help_text' => E::ts('Specifies if invoices can be paid with online bank transfers'),
     'html_type' => 'Select',
-    'html_attributes' => array(
+    'html_attributes' => [
       '1' => E::ts('Yes'),
       '0' => E::ts('No'),
-    ),
+    ],
     'quick_form_type' => 'Element',
-  ),
-  'quickbooks_allow_creditcard' => array(
+  ],
+  'quickbooks_allow_creditcard' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_allow_creditcard',
@@ -278,13 +278,13 @@ return array(
     'description' => E::ts('Specifies if online credit card payments are allowed for invoices'),
     'help_text' => E::ts('Specifies if online credit card payments are allowed for invoices'),
     'html_type' => 'Select',
-    'html_attributes' => array(
+    'html_attributes' => [
       '1' => E::ts('Yes'),
       '0' => E::ts('No'),
-    ),
+    ],
     'quick_form_type' => 'Element',
-  ),
-  'quickbooks_customer_memo' => array(
+  ],
+  'quickbooks_customer_memo' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_customer_memo',
@@ -297,9 +297,9 @@ return array(
     'description' => E::ts('Custom Memo text (instead of the contribution source)'),
     'help_text' => E::ts('if you enter text into this field it will be displayed on the invoice as the Memo instead of the source'),
     'html_type' => 'Textarea',
-    'html_attributes' => array(
+    'html_attributes' => [
       'size' => 200,
-    ),
+    ],
     'quick_form_type' => 'Element',
-  ),
-);
+  ],
+];


### PR DESCRIPTION
* Convert to short array syntax (PHP code standards).
* Upgrade civix (compatibility with current CiviCRM).
* Allow to push a single contact via API (useful for testing/debugging etc).
* Fix bug saving settings that wiped the tokens and forced a re-authorization every time settings were saved (this was quite an annoying bug caused by checking the wrong array to see if auth keys had changed.
* Add spec to Civiquickbooks.Contactpull API.