### PR TITLE
Fix crashes when there is a single quote in names

### DIFF
--- a/CRM/Civiquickbooks/Contact.php
+++ b/CRM/Civiquickbooks/Contact.php
@@ -534,8 +534,8 @@ class CRM_Civiquickbooks_Contact {
   protected function getQBOContactByName($name, $givenName = NULL) {
     $query = (
       empty($givenName)
-      ? sprintf('SELECT * FROM Customer WHERE FullyQualifiedName = \'%s\'', $name)
-      : sprintf('SELECT * FROM Customer WHERE FamilyName = \'%s\' AND GivenName = \'%s\'', $name, $givenName)
+      ? sprintf("SELECT * FROM Customer WHERE FullyQualifiedName = '%s'", addslashes($name))
+      : sprintf("SELECT * FROM Customer WHERE FamilyName = '%s' AND GivenName = '%s'", addslashes($name), addslashes($givenName))
     );
 
     try {


### PR DESCRIPTION
In French, we often have apostrophe (single quote) in names.

This is not properly escaped in the sql sent to qbo which causes an error.