### PR TITLE
Move navigation menu and settings

### DIFF
--- a/civiquickbooks.php
+++ b/civiquickbooks.php
@@ -67,44 +67,6 @@ function civiquickbooks_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
 }
 
 /**
- * Implements hook_civicrm_navigationMenu().
- *
- * Adds entries to the navigation menu.
- */
-function civiquickbooks_civicrm_navigationMenu(&$menu) {
-  $item[] = [
-    'label' => E::ts('QuickBooks'),
-    'name' => 'QuickBooks',
-    'url' => NULL,
-    'permission' => 'administer CiviCRM',
-    'operator' => NULL,
-    'separator' => NULL,
-  ];
-  _civiquickbooks_civix_insert_navigation_menu($menu, 'Administer', $item[0]);
-
-  $item[] = [
-    'label' => E::ts('Quickbooks Settings'),
-    'name' => 'Quickbooks Settings',
-    'url' => 'civicrm/quickbooks/settings',
-    'permission' => 'administer CiviCRM',
-    'operator' => NULL,
-    'separator' => NULL,
-  ];
-  _civiquickbooks_civix_insert_navigation_menu($menu, 'Administer/QuickBooks', $item[1]);
-
-  $item[] = [
-    'label' => E::ts('Synchronize contacts'),
-    'name' => 'Contact Sync',
-    'url' => 'civicrm/a/#/accounts/contact/sync/quickbooks',
-    'permission' => 'administer CiviCRM',
-    'operator' => NULL,
-    'separator' => NULL,
-  ];
-  _civiquickbooks_civix_insert_navigation_menu($menu, 'Administer/QuickBooks', $item[2]);
-  _civiquickbooks_civix_navigationMenu($menu);
-}
-
-/**
  * Map quickbooks accounts data to generic data.
  *
  * @param array $accountsData

--- a/managed/navigation.mgd.php
+++ b/managed/navigation.mgd.php
@@ -1,0 +1,29 @@
+<?php
+use CRM_Civiquickbooks_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'Navigation_Accountsync_Quickbooks_Settings',
+    'entity' => 'Navigation',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'domain_id' => 'current_domain',
+        'label' => E::ts('Quickbooks Settings'),
+        'name' => 'Quickbooks Settings',
+        'url' => 'civicrm/admin/setting/quickbooks',
+        'icon' => NULL,
+        'permission' => [
+          'administer CiviCRM system',
+        ],
+        'permission_operator' => 'AND',
+        'parent_id.name' => 'Accounts_System',
+        'is_active' => TRUE,
+        'has_separator' => 0,
+        'weight' => 10,
+      ],
+    ],
+  ],
+];

--- a/xml/Menu/civiquickbooks.xml
+++ b/xml/Menu/civiquickbooks.xml
@@ -9,7 +9,7 @@
         <access_arguments>access CiviCRM</access_arguments>
     </item>
     <item>
-        <path>civicrm/quickbooks/settings</path>
+        <path>civicrm/admin/setting/quickbooks</path>
         <page_callback>CRM_Civiquickbooks_Form_Settings</page_callback>
         <title>QuickBooks Online Settings</title>
         <access_arguments>access CiviCRM</access_arguments>


### PR DESCRIPTION
The next version of accountsync will have a menu item with shared functionality (eg. contact/invoice errors, matching) in the menu entry Administer->CiviContribute->Accounts integration. Xero menu entries have also moved to that location.

Also, "standard" path for settings is civicrm/admin instead of civicrm/.