### PR TITLE
Restore account_sync settings to settings form

### DIFF
--- a/CRM/Civiquickbooks/Form/Settings.php
+++ b/CRM/Civiquickbooks/Form/Settings.php
@@ -7,48 +7,15 @@ use CRM_Civiquickbooks_ExtensionUtil as E;
  *
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC43/QuickForm+Reference
  */
-class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
-
-  private $_settingFilter = ['group' => 'civiquickbooks'];
-
-  // Form re-used from CiviXero
-  private $_submittedValues = [];
-
-  private $_settings = [];
+class CRM_Civiquickbooks_Form_Settings extends CRM_Admin_Form_Setting {
 
   public function buildQuickForm() {
-    $settings = $this->getFormSettings();
-    $description = [];
 
     $QBCredentials = CRM_Quickbooks_APIHelper::getQuickBooksCredentials();
 
-    foreach ($settings as $name => $setting) {
-      if (isset($setting['quick_form_type'])) {
-        $add = 'add' . $setting['quick_form_type'];
+    $this->addFieldsDefinedInSettingsMetadata();
 
-        if ($add == 'addElement') {
-		  $this->$add($setting['html_type'], $name, $setting['title'], $setting['html_attributes'] ?? NULL);
-        }
-        elseif ($setting['html_type'] == 'Select') {
-          $optionValues = [];
-          if (!empty($setting['pseudoconstant']) && !empty($setting['pseudoconstant']['optionGroupName'])) {
-            $optionValues = CRM_Core_OptionGroup::values($setting['pseudoconstant']['optionGroupName'], FALSE, FALSE, FALSE, NULL, 'name');
-          }
-          elseif (!empty($setting['pseudoconstant']) && !empty($setting['pseudoconstant']['callback'])) {
-            $callBack = Civi\Core\Resolver::singleton()
-              ->get($setting['pseudoconstant']['callback']);
-            $optionValues = call_user_func_array($callBack, $optionValues);
-          }
-          $this->add('select', $setting['name'], $setting['title'], $optionValues, FALSE, $setting['html_attributes']);
-        }
-        else {
-          $this->$add($name, $setting['title']);
-        }
-
-        $description[$name] = $setting['description'];
-      }
-    }
-
+    $this->assign('entityInClassFormat', 'setting');
     $this->addButtons([
       [
         'type' => 'submit',
@@ -68,7 +35,7 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
     if ((!empty($QBCredentials['clientID']) && !empty($QBCredentials['clientSecret']) && empty($QBCredentials['accessToken']) && empty($QBCredentials['refreshToken']) && empty($QBCredentials['realMId'])) || $isRefreshTokenExpired) {
       $url = str_replace('&amp;', '&', CRM_Utils_System::url('civicrm/quickbooks/OAuth', NULL, TRUE, NULL));
     }
-	$this->assign('redirect_url', $url ?? NULL);
+    $this->assign('redirect_url', $url ?? NULL);
 
     $this->assign('isRefreshTokenExpired', $isRefreshTokenExpired);
 
@@ -79,57 +46,16 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
 
     $this->assign('showClientKeysMessage', $showClientKeysMessage);
 
-    $this->assign('description_array', $description);
-
     $this->assign('pageTitle', 'QuickBooks Online Settings');
-
-    // export form elements
-    $this->assign('elementNames', $this->getRenderableElementNames());
-
-    parent::buildQuickForm();
   }
 
   public function postProcess() {
-    $this->_submittedValues = $this->exportValues();
-
-    $this->saveSettings();
     parent::postProcess();
+    $this->saveSettings();
+
     header('Location: ' . $_SERVER['REQUEST_URI']);
   }
 
-  /**
-   * Get the fields/elements defined in this form.
-   *
-   * @return array (string)
-   */
-  public function getRenderableElementNames() {
-    // The _elements list includes some items which should not be
-    // auto-rendered in the loop -- such as "qfKey" and "buttons". These
-    // items don't have labels. We'll identify renderable by filtering on
-    // the 'label'.
-    $elementNames = [];
-    foreach ($this->_elements as $element) {
-      $label = $element->getLabel();
-      if (!empty($label)) {
-        $elementNames[] = $element->getName();
-      }
-    }
-    return $elementNames;
-  }
-
-  /**
-   * Get the settings we are going to allow to be set on this form.
-   *
-   * @return array
-   */
-  public function getFormSettings() {
-    if (empty($this->_settings)) {
-      $settings = civicrm_api3('setting', 'getfields', ['filters' => $this->_settingFilter]);
-    }
-    $extraSettings = civicrm_api3('setting', 'getfields', ['filters' => ['group' => 'accountsync']]);
-    $settings = $settings['values'] + $extraSettings['values'];
-    return $settings;
-  }
 
   /**
    * Get the settings we are going to allow to be set on this form.
@@ -137,20 +63,7 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
    * @return array
    */
   public function saveSettings() {
-    $settings = $this->getFormSettings();
-    $values = array_intersect_key($this->_submittedValues, $settings);
-
-    // Fix for unsetting a checkbox. When setting a checkbox,
-    // quickbooks_bool_value => 1 is returned. But when unsetting a checkbox,
-    // quickbooks_bool_value => 0 is NOT returned. Absence of a checkbox
-    // attribute should be interpreted as setting its value to 0.
-    foreach ($settings as $setting_name => $setting_info) {
-        if ($setting_info['type'] == "Boolean" && !array_key_exists($setting_name, $values)) {
-            $values[$setting_name] = 0;
-        }
-    }
-
-    civicrm_api3('setting', 'create', $values);
+    $values = $this->_submitValues;
 
     $previousCredentials = CRM_Quickbooks_APIHelper::getQuickBooksCredentials();
     $clientIDChanged = $previousCredentials['clientID'] !== $values['quickbooks_consumer_key'];
@@ -168,23 +81,6 @@ class CRM_Civiquickbooks_Form_Settings extends CRM_Core_Form {
         ]
       );
     }
-
-    return $settings;
-  }
-
-  /**
-   * Set defaults for form.
-   *
-   * @see CRM_Core_Form::setDefaultValues()
-   */
-  public function setDefaultValues() {
-    $existing = civicrm_api3('setting', 'get', ['return' => array_keys($this->getFormSettings())]);
-    $defaults = [];
-    $domainID = CRM_Core_Config::domainID();
-    foreach ($existing['values'][$domainID] as $name => $value) {
-      $defaults[$name] = $value;
-    }
-    return $defaults;
   }
 
 }

--- a/civiquickbooks.php
+++ b/civiquickbooks.php
@@ -40,6 +40,24 @@ function civiquickbooks_civicrm_enable() {
 }
 
 /**
+ * Implements hook_civicrm_alterSettingsMetaData(().
+ *
+ * This hook sets the default for each setting to our preferred value.
+ * It can still be overridden by specifically setting the setting.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsMetaData/
+ */
+function civiquickbooks_civicrm_alterSettingsMetaData(array &$settingsMetaData): void {
+  $weight = 100;
+  foreach ($settingsMetaData as $index => $setting) {
+    if (($setting['group'] ?? '') === 'accountsync') {
+      $settingsMetaData[$index]['settings_pages'] = ['quickbooks' => ['weight' => $weight]];
+    }
+    $weight++;
+  }
+}
+
+/**
  * Map quickbooks accounts data to generic data.
  *
  * @param array $accountsData

--- a/settings/civiquickbooks.setting.php
+++ b/settings/civiquickbooks.setting.php
@@ -15,11 +15,11 @@ return [
     'is_contact' => 0,
     'description' => E::ts('Initial client id retrieved from quickbooks website'),
     'help_text' => E::ts('Initial client id retrieved from quickbooks website'),
-    'html_type' => 'Text',
+    'html_type' => 'text',
     'html_attributes' => [
       'size' => 50,
     ],
-    'quick_form_type' => 'Element',
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
   'quickbooks_shared_secret' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
@@ -33,11 +33,11 @@ return [
     'is_contact' => 0,
     'description' => E::ts('Initial client secret retrieved from quickbooks website'),
     'help_text' => E::ts('Initial client secret retrieved from quickbooks website'),
-    'html_type' => 'Text',
+    'html_type' => 'text',
     'html_attributes' => [
       'size' => 50,
     ],
-    'quick_form_type' => 'Element',
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
   'quickbooks_baseurl' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
@@ -51,18 +51,21 @@ return [
     'is_contact' => 0,
     'description' => E::ts('Development or Production mode.'),
     'help_text' => E::ts('Use Development to test with your sandbox.'),
-    'html_type' => 'Select',
-    'html_attributes' => array(
+    'html_type' => 'select',
+    'options' => array(
       'Production' => E::ts('Production'),
       'Development' => E::ts('Development'),
     ),
-    'quick_form_type' => 'Element',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+    ],
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
   'quickbooks_access_token' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_access_token',
-    'type' => 'String',
+    'type' => 'string',
     'html_type' => NULL,
     'add' => '4.7',
     'default' => '',
@@ -76,7 +79,7 @@ return [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_refresh_token',
-    'type' => 'String',
+    'type' => 'string',
     'html_type' => NULL,
     'add' => '4.7',
     'default' => '',
@@ -90,7 +93,7 @@ return [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_state_token',
-    'type' => 'String',
+    'type' => 'string',
     'html_type' => NULL,
     'add' => '4.7',
     'default' => '',
@@ -112,12 +115,12 @@ return [
     'is_contact' => 0,
     'description' => E::ts('Expiry date of the current access token'),
     'help_text' => E::ts('Expiry date of the current access token'),
-    'html_type' => 'Text',
+    'html_type' => 'text',
     'html_attributes' => [
       'size' => 50,
       'readonly' => 'true',
     ],
-    'quick_form_type' => 'Element',
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
   'quickbooks_refresh_token_expiryDate' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
@@ -131,12 +134,12 @@ return [
     'is_contact' => 0,
     'description' => E::ts('Expiry date of the current refresh token'),
     'help_text' => E::ts('Expiry date of the current refresh token'),
-    'html_type' => 'Text',
+    'html_type' => 'text',
     'html_attributes' => [
       'size' => 50,
       'readonly' => 'true',
     ],
-    'quick_form_type' => 'Element',
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
   'quickbooks_email_invoice' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
@@ -150,13 +153,16 @@ return [
     'is_contact' => 0,
     'description' => E::ts('Whether an email should be sent to the Invoicee when a new Invoice is created in Quickbooks.'),
     'help_text' => E::ts('Whether an email should be sent to the Invoicee when a new Invoice is created in Quickbooks.'),
-    'html_type' => 'Select',
-    'html_attributes' => [
+    'html_type' => 'select',
+    'options' => [
       'never' => E::ts('Never'),
       'unpaid' => E::ts('Unpaid Invoices Only'),
       'always' => E::ts('Always'),
     ],
-    'quick_form_type' => 'Element',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+    ],
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
   'quickbooks_activate_qbo_logging' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
@@ -171,7 +177,7 @@ return [
     'description' => E::ts('If selected, QBO will log potentially sensitive data to the QBO Log Directory.'),
     'help_text' => E::ts('If selected, QBO will log potentially sensitive data to the QBO Log Directory.'),
     'html_type' => 'checkbox',
-    'quick_form_type' => 'Element',
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
   'quickbooks_realmId' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
@@ -185,7 +191,7 @@ return [
     'is_contact' => 0,
     'description' => E::ts('realmId retrieved when got access token'),
     'help_text' => E::ts('realmId retrieved when got access token'),
-    'html_type' => 'Text',
+    'html_type' => 'text',
     'html_attributes' => [
       'size' => 50,
       'readonly' => 'true',
@@ -203,7 +209,7 @@ return [
     'is_contact' => 0,
     'description' => E::ts('QuickBooks company country code for differentiating US and other countries during including tax in invoices.'),
     'help_text' => E::ts('QuickBooks company country code for differentiating US and other countries during including tax in invoices.'),
-    'html_type' => 'Text',
+    'html_type' => 'text',
     'html_attributes' => [
       'size' => 50,
       'readonly' => 'true',
@@ -221,12 +227,15 @@ return [
     'is_contact' => 0,
     'description' => E::ts('Whether the invoice numbers should be generated in CiviCRM or QuickBooks.'),
     'help_text' => E::ts('Whether the invoice numbers should be generated in CiviCRM or QuickBooks.'),
-    'html_type' => 'Select',
-    'html_attributes' => [
+    'html_type' => 'select',
+    'options' => [
       'civi' => E::ts('CiviCRM'),
       'qb' => E::ts('QuickBooks'),
     ],
-    'quick_form_type' => 'Element',
+    'html_attributes' => [
+      'class' => 'crm-select2',
+    ],
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
   'quickbooks_invoice_prefix' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
@@ -247,17 +256,17 @@ return [
       [ 1 => 'https://www.php.net/manual/en/function.printf.php',
         2 => 'Civi-%07d'
       ]),
-    'html_type' => 'Text',
+    'html_type' => 'text',
     'html_attributes' => [
       'size' => 10,
     ],
-    'quick_form_type' => 'Element',
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
   'quickbooks_allow_ach' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_allow_ach',
-    'type' => 'String',
+    'type' => 'Boolean',
     'add' => '4.7',
     'default' => '0',
     'title' => E::ts('Allow ACH Payment?'),
@@ -265,18 +274,14 @@ return [
     'is_contact' => 0,
     'description' => E::ts('Specifies if invoices can be paid with online bank transfers'),
     'help_text' => E::ts('Specifies if invoices can be paid with online bank transfers'),
-    'html_type' => 'Select',
-    'html_attributes' => [
-      '1' => E::ts('Yes'),
-      '0' => E::ts('No'),
-    ],
-    'quick_form_type' => 'Element',
+    'html_type' => 'checkbox',
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
   'quickbooks_allow_creditcard' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
     'group' => 'civiquickbooks',
     'name' => 'quickbooks_allow_creditcard',
-    'type' => 'String',
+    'type' => 'Boolean',
     'add' => '4.7',
     'default' => '0',
     'title' => E::ts('Allow Online Credit Card Payment?'),
@@ -284,12 +289,8 @@ return [
     'is_contact' => 0,
     'description' => E::ts('Specifies if online credit card payments are allowed for invoices'),
     'help_text' => E::ts('Specifies if online credit card payments are allowed for invoices'),
-    'html_type' => 'Select',
-    'html_attributes' => [
-      '1' => E::ts('Yes'),
-      '0' => E::ts('No'),
-    ],
-    'quick_form_type' => 'Element',
+    'html_type' => 'checkbox',
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
   'quickbooks_customer_memo' => [
     'group_name' => E::ts('QuickBooks Online Settings'),
@@ -303,10 +304,10 @@ return [
     'is_contact' => 0,
     'description' => E::ts('Custom Memo text (instead of the contribution source)'),
     'help_text' => E::ts('if you enter text into this field it will be displayed on the invoice as the Memo instead of the source'),
-    'html_type' => 'Textarea',
+    'html_type' => 'textarea',
     'html_attributes' => [
       'size' => 200,
     ],
-    'quick_form_type' => 'Element',
+    'settings_pages' => ['quickbooks' => ['weight' => 1]],
   ],
 ];

--- a/templates/CRM/Civiquickbooks/Form/Settings.tpl
+++ b/templates/CRM/Civiquickbooks/Form/Settings.tpl
@@ -1,30 +1,27 @@
 {* HEADER *}
+<div class="crm-block crm-form-block crm-{$entityInClassFormat}-block">
+
 <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="top"}
 </div>
 
-{* FIELDS (AUTOMATIC LAYOUT) *}
-{foreach from=$elementNames item=elementName}
-    <div class="crm-section">
-        <div class="label">{$form.$elementName.label}</div>
-        <div class="content">
-            {if $elementName == 'quickbooks_access_token_expiryDate' or $elementName == 'quickbooks_refresh_token_expiryDate'}
-                {$form.$elementName.value|crmDate}
-            {else}
-                {$form.$elementName.html}
-            {/if}
-        </div>
-        <div class="description content">{$description_array.$elementName}</div>
-
+<table class="form-layout">
+  {foreach from=$fields item=fieldSpec}
+    {assign var=fieldName value=$fieldSpec.name}
+    <tr class="crm-{$entityInClassFormat}-form-block-{$fieldName}">
+      {include file="CRM/Core/Form/Field.tpl"}
         {* Add authorization details after the expiryDate information *}
-        {if $elementName == 'quickbooks_access_token_expiryDate'}
+        {if $fieldName == 'quickbooks_access_token_expiryDate'}
             {if $showClientKeysMessage}
+                <tr><td></td><td>
                 <p class="content">The Client ID and Client Secret are part of the QuickBooks Online App configuration.
                     To find the values for these, please <a
                             href="https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0#obtain-oauth2-credentials-for-your-app"
                             target="_blank">follow the instructions on the Intuit site</a>.</p>
+                </td></tr>
             {/if}
             {if $redirect_url}
+                <tr><td></td><td>
                 <p class="content messages status no-popup crm-not-you-message">
                     <strong>
                         {if $isRefreshTokenExpired}
@@ -52,13 +49,15 @@
                         {$redirect_url}
                     {/if}
                 </p>
+                </td></tr>
             {/if}
         {/if}
-        <div class="clear"></div>
-    </div>
-{/foreach}
+        </tr>
+  {/foreach}
+</table>
 
 {* FOOTER *}
 <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>
 </div>


### PR DESCRIPTION
This PR upgrades the setting form. Removing the deprecated properties in the settings definition.  And restores the account_sync settings on the setting pages.  

Based off of https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/tree/master

If the authorization is split off to it's own form (like Civixero) Then I believe you should be able to just use CRM_Admin_Form_Generic as the page_callback for the settings directly (like Civixero).