### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Civiquickbooks/Contact.php
+++ b/CRM/Civiquickbooks/Contact.php
@@ -154,7 +154,7 @@ class CRM_Civiquickbooks_Contact {
           'accounts_modified_date',
           date('Y-m-d H:i:s', strtotime($contact->MetaData->LastUpdatedTime)),
           'id');
-      } catch (CiviCRM_API3_Exception $e) {
+      } catch (CRM_Core_Exception $e) {
         CRM_Core_Session::setStatus(ts('Failed to store ') . $account_contact['accounts_display_name']
           . ts(' with error ') . $e->getMessage(),
           ts('Contact Pull failed'));
@@ -260,7 +260,7 @@ class CRM_Civiquickbooks_Contact {
                   // Causes: OAuth is not valid, API throttling has occured.
                   // Stop processing this run.
                   $abort_loop = TRUE;
-                  throw new CiviCRM_API3_Exception('Authentication failure doing QBO contact push, aborting', 9000 + $error_code);
+                  throw new CRM_Core_Exception('Authentication failure doing QBO contact push, aborting', 9000 + $error_code);
                   break;
 
                 default:

--- a/CRM/Civiquickbooks/Helper.php
+++ b/CRM/Civiquickbooks/Helper.php
@@ -7,7 +7,7 @@ class CRM_Civiquickbooks_Helper {
   /**
    * @param int $contactID
    *
-   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public static function addSyncErrorTag(int $contactID) {
@@ -27,7 +27,7 @@ class CRM_Civiquickbooks_Helper {
   /**
    * @param int $contactID
    *
-   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public static function removeSyncErrorTag(int $contactID) {

--- a/CRM/Civiquickbooks/Invoice.php
+++ b/CRM/Civiquickbooks/Invoice.php
@@ -55,7 +55,7 @@ class CRM_Civiquickbooks_Invoice {
    * @return bool
    *
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\IdsException
    * @throws \QuickBooksOnline\API\Exception\SdkException
    */
@@ -86,7 +86,7 @@ class CRM_Civiquickbooks_Invoice {
 
           if (empty($accountsInvoice)) {
             civicrm_api3('AccountInvoice', 'create', ['id' => $record['id'], 'accounts_needs_update' => 0]);
-            throw new CiviCRM_API3_Exception(E::ts('AccountInvoice object for %1 is empty', [1 => $record['id']]), 'empty_invoice');
+            throw new CRM_Core_Exception(E::ts('AccountInvoice object for %1 is empty', [1 => $record['id']]), 'empty_invoice');
           }
 
           $proceed = TRUE;
@@ -148,7 +148,7 @@ class CRM_Civiquickbooks_Invoice {
       }
       return TRUE;
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       throw new CRM_Core_Exception('Invoice Push aborted due to: ' . $e->getMessage());
     }
   }
@@ -201,7 +201,7 @@ class CRM_Civiquickbooks_Invoice {
         throw new CRM_Core_Exception(ts('Not all records were saved: ') . json_encode($errors, JSON_PRETTY_PRINT), 'incomplete', $errors);
       }
       return TRUE;
-    } catch (CiviCRM_API3_Exception $e) {
+    } catch (CRM_Core_Exception $e) {
       throw new CRM_Core_Exception('Invoice Pull aborted due to: ' . $e->getMessage());
     }
   }
@@ -213,7 +213,7 @@ class CRM_Civiquickbooks_Invoice {
    * @param $contribution_id
    * @param $account_invoice
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\SdkException
    * @throws \QuickBooksOnline\API\Exception\IdsException
    */
@@ -263,7 +263,7 @@ class CRM_Civiquickbooks_Invoice {
    * @param $invoice_id
    * @param $dataService
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\SdkException
    * @throws \QuickBooksOnline\API\Exception\IdsException
    */
@@ -313,7 +313,7 @@ class CRM_Civiquickbooks_Invoice {
    * @param \QuickBooksOnline\API\DataService\DataService $dataService
    *
    * @return \Exception|\QuickBooksOnline\API\Data\IPPIntuitEntity|string|null
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\IdsException
    * @throws \QuickBooksOnline\API\Exception\SdkException
    */
@@ -348,7 +348,7 @@ class CRM_Civiquickbooks_Invoice {
         ]);
 
         if ($result['is_error']) {
-          throw new CiviCRM_API3_Exception('Contribution status update failed: id: ' . $record['contribution_id'] . ' of Invoice ' . $invoice['Id'], 'qbo_contribution_status');
+          throw new CRM_Core_Exception('Contribution status update failed: id: ' . $record['contribution_id'] . ' of Invoice ' . $invoice['Id'], 'qbo_contribution_status');
         }
 
         $record['accounts_needs_update'] = 0;
@@ -367,7 +367,7 @@ class CRM_Civiquickbooks_Invoice {
         $result = CRM_Core_DAO::setFieldValue('CRM_Contribute_DAO_Contribution', $record['contribution_id'], 'contribution_status_id', $this->contribution_status_by_value['cancelled'], 'id');
 
         if ($result == FALSE) {
-          throw new CiviCRM_API3_Exception('Contribution status update failed: id: ' . $record['contribution_id'] . ' of Invoice ' . $invoice['Id'], 'qbo_contribution_status');
+          throw new CRM_Core_Exception('Contribution status update failed: id: ' . $record['contribution_id'] . ' of Invoice ' . $invoice['Id'], 'qbo_contribution_status');
         }
 
         $record['accounts_needs_update'] = 0;
@@ -425,7 +425,7 @@ class CRM_Civiquickbooks_Invoice {
    * @param array $record
    *
    * @return array
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function getAccountsInvoice($record) {
     $accountsInvoiceID = isset($record['accounts_invoice_id']) ? $record['accounts_invoice_id'] : NULL;
@@ -485,7 +485,7 @@ class CRM_Civiquickbooks_Invoice {
    * @return array|bool
    *   Contact Object/ array as expected by accounts package
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function mapToAccounts($db_contribution, $accountsID, $SyncToken, $qb_id) {
     static $tmp = NULL;
@@ -503,7 +503,7 @@ class CRM_Civiquickbooks_Invoice {
       ]);
 
       if (empty($db_line_items['count'])) {
-        throw new CiviCRM_API3_Exception('No LineItems for Contribution: ' . $contributionID . '; push aborted.',
+        throw new CRM_Core_Exception('No LineItems for Contribution: ' . $contributionID . '; push aborted.',
           'qbo_contribution_line_item');
       }
 
@@ -565,7 +565,7 @@ class CRM_Civiquickbooks_Invoice {
             ];
 
             $tax_codes[] = $tmp;
-          } catch (CiviCRM_API3_Exception $e) {
+          } catch (CRM_Core_Exception $e) {
             $tax_errormsg[] = ts(
               'Could not load "Sales Tax Account is" relationship for FinancialType %1. Error: %2',
               [
@@ -693,7 +693,7 @@ class CRM_Civiquickbooks_Invoice {
       }
 
       if (empty($line_items)) {
-        throw new CiviCRM_API3_Exception("No valid LineItems in Contribution to push:\n" . $QBO_errormsg, 'qbo_invoice_line_items');
+        throw new CRM_Core_Exception("No valid LineItems in Contribution to push:\n" . $QBO_errormsg, 'qbo_invoice_line_items');
       }
 
       $new_invoice += [
@@ -717,7 +717,7 @@ class CRM_Civiquickbooks_Invoice {
           'group' => 'QuickBooks Online Settings',
         ]);
       } catch (Exception $e) {
-        throw new CiviCRM_API3_Exception(
+        throw new CRM_Core_Exception(
           E::ts('Error getting Invoice generation setting %1', [1 => $e->getMessage()]),
           'qbo_invoice_creation'
         );
@@ -742,7 +742,7 @@ class CRM_Civiquickbooks_Invoice {
             'group' => 'QuickBooks Online Settings',
           ]);
         } catch (Exception $e) {
-          throw new CiviCRM_API3_Exception(
+          throw new CRM_Core_Exception(
             E::ts('Error getting Invoice generation setting %1', [1 => $e->getMessage()]),
             'qbo_invoice_creation'
           );
@@ -757,7 +757,7 @@ class CRM_Civiquickbooks_Invoice {
           'group' => 'QuickBooks Online Settings',
         ]);
       } catch (Exception $e) {
-        throw new CiviCRM_API3_Exception(
+        throw new CRM_Core_Exception(
           E::ts('Error getting Invoice generation setting %1', [1 => $e->getMessage()]),
           'qbo_invoice_creation'
         );
@@ -790,7 +790,7 @@ class CRM_Civiquickbooks_Invoice {
       try {
         return \QuickBooksOnline\API\Facades\Invoice::create($new_invoice);
       } catch (Exception $e) {
-        throw new CiviCRM_API3_Exception(
+        throw new CRM_Core_Exception(
           E::ts('Error creating Invoice for %1: %2', [1 => $contributionID, 2 => $e->getMessage()]),
           'qbo_invoice_creation'
         );
@@ -805,7 +805,7 @@ class CRM_Civiquickbooks_Invoice {
    *                Assumes FullyQualifiedName if containing a colon (:)
    *
    * @return int|FALSE
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\SdkException
    */
   public static function getQBOItem($name) {
@@ -834,7 +834,7 @@ class CRM_Civiquickbooks_Invoice {
    * @param $name - Name of Tax Code.
    *
    * @return int|FALSE
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\SdkException
    */
   public static function getQBOTaxCode($name) {
@@ -898,7 +898,7 @@ class CRM_Civiquickbooks_Invoice {
    * @param $line_items
    *
    * @return array|bool
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\SdkException
    */
   protected function generateTaxDetails($line_items) {
@@ -949,7 +949,7 @@ class CRM_Civiquickbooks_Invoice {
    * @param int $limit
    *
    * @return array
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function findPushContributions($params, $limit) {
     $accountInvoices = AccountInvoice::get()
@@ -993,7 +993,7 @@ class CRM_Civiquickbooks_Invoice {
    * @return array
    *   Array of any errors
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function savePushResponse($result, $record, $responseErrors = NULL) {
 

--- a/CRM/Civiquickbooks/Page/OAuthQBO.php
+++ b/CRM/Civiquickbooks/Page/OAuthQBO.php
@@ -21,7 +21,7 @@ class CRM_Civiquickbooks_Page_OAuthQBO extends CRM_Core_Page {
    * Get Login Helper to get Redirection URL and Access/Refresh Tokens.
    *
    * @return \QuickBooksOnline\API\Core\OAuth\OAuth2\OAuth2LoginHelper
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\SdkException
    */
   private function getLoginHelper() {
@@ -33,7 +33,7 @@ class CRM_Civiquickbooks_Page_OAuthQBO extends CRM_Core_Page {
   /**
    * Redirect from CiviCRM to QuickBooks for App authorization.
    *
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\SdkException
    */
   private function redirectForAuth() {
@@ -112,7 +112,7 @@ class CRM_Civiquickbooks_Page_OAuthQBO extends CRM_Core_Page {
 
           try {
             civicrm_api3('Setting', 'create', ['quickbooks_company_country' => $_company_country]);
-          } catch (CiviCRM_API3_Exception $e) {
+          } catch (CRM_Core_Exception $e) {
             // Handle error here.
             $errorMessage = $e->getMessage();
             $errorCode = $e->getErrorCode();

--- a/CRM/Quickbooks/APIHelper.php
+++ b/CRM/Quickbooks/APIHelper.php
@@ -30,7 +30,7 @@ class CRM_Quickbooks_APIHelper {
    * Generate dataservice object to verify and login into QuickBooks
    *
    * @return \QuickBooksOnline\API\DataService\DataService|null
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\SdkException
    */
   public static function getLoginDataServiceObject() {
@@ -79,7 +79,7 @@ class CRM_Quickbooks_APIHelper {
    * Generates data service object for accounting into QuickBooks.
    *
    * @return \QuickBooksOnline\API\DataService\DataService|null
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\SdkException
    */
   public static function getAccountingDataServiceObject($forRefreshToken = FALSE) {
@@ -143,7 +143,7 @@ class CRM_Quickbooks_APIHelper {
   /**
    * Refresh QuickBooks access token if required.
    *
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    * @throws \QuickBooksOnline\API\Exception\SdkException
    */
   private static function refreshAccessTokenIfRequired() {
@@ -193,7 +193,7 @@ class CRM_Quickbooks_APIHelper {
    * Get all required credentials to connect with QuickBooks
    *
    * @return array
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   public static function getQuickBooksCredentials() {
     $quickBooksSettings = civicrm_api3('Setting', 'get', ['group' => "QuickBooks Online Settings"]);

--- a/api/v3/Civiquickbooks/Contactpull.php
+++ b/api/v3/Civiquickbooks/Contactpull.php
@@ -37,7 +37,7 @@ function _civicrm_api3_civiquickbooks_Contactpull_spec(&$spec) {
  */
 function civicrm_api3_civiquickbooks_Contactpull($params) {
   if (!CRM_Quickbooks_APIHelper::isAuthorized()) {
-    throw new CiviCRM_API3_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
+    throw new CRM_Core_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
   }
 
   $quickbooks = new CRM_Civiquickbooks_Contact();

--- a/api/v3/Civiquickbooks/Contactpush.php
+++ b/api/v3/Civiquickbooks/Contactpush.php
@@ -41,11 +41,11 @@ function _civicrm_api3_civiquickbooks_ContactPush_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_civiquickbooks_ContactPush($params) {
   if (!CRM_Quickbooks_APIHelper::isAuthorized()) {
-    throw new CiviCRM_API3_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
+    throw new CRM_Core_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
   }
 
   $options = _civicrm_api3_get_options_from_params($params);

--- a/api/v3/Civiquickbooks/Invoicepull.php
+++ b/api/v3/Civiquickbooks/Invoicepull.php
@@ -26,11 +26,11 @@ function _civicrm_api3_civiquickbooks_InvoicePull_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_civiquickbooks_InvoicePull($params) {
   if (!CRM_Quickbooks_APIHelper::isAuthorized()) {
-    throw new CiviCRM_API3_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
+    throw new CRM_Core_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
   }
 
   $options = _civicrm_api3_get_options_from_params($params);

--- a/api/v3/Civiquickbooks/Invoicepush.php
+++ b/api/v3/Civiquickbooks/Invoicepush.php
@@ -26,11 +26,11 @@ function _civicrm_api3_civiquickbooks_InvoicePush_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_civiquickbooks_InvoicePush($params) {
   if (!CRM_Quickbooks_APIHelper::isAuthorized()) {
-    throw new CiviCRM_API3_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
+    throw new CRM_Core_Exception('Not authorized! Reauthorize QuickBooks application to continue syncing contacts and contributions updates to QuickBooks');
   }
 
   $options = _civicrm_api3_get_options_from_params($params);


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.