### PR TITLE
Support contribution with more than 25 line items

### DIFF
--- a/CRM/Civiquickbooks/Invoice.php
+++ b/CRM/Civiquickbooks/Invoice.php
@@ -554,6 +554,7 @@ class CRM_Civiquickbooks_Invoice {
     if (in_array($contri_status_in_lower, $status_array)) {
       $db_line_items = civicrm_api3('LineItem', 'get', [
         'contribution_id' => $contributionID,
+        'options' => ['limit' => 0],
       ]);
 
       if (empty($db_line_items['count'])) {


### PR DESCRIPTION
Old bug with api3, the default number of results returned is 25.

LineItems, especially with multiple participants registration and multiple price options can go well over this limit as we just learned.